### PR TITLE
Tweak schedule of daily builds

### DIFF
--- a/.github/workflows/dance.yml
+++ b/.github/workflows/dance.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
   schedule:
-    - cron: "42 3 * * *"
+    - cron: "12 3 * * *" # after FerretDB's Docker workflow
 
 env:
   GOPATH: /home/runner/go

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
   schedule:
-    - cron: "42 3 * * *"
+    - cron: "12 3 * * *"
 
 env:
   GOPATH: /home/runner/go


### PR DESCRIPTION
Sync FerretDB's and dance's build times, so dance tests run after the new Docker image is built.

See FerretDB/FerretDB#794.