### PR TITLE
Use `github.head_ref` instead of `github.ref`

### DIFF
--- a/.github/workflows/conform-pr.yml
+++ b/.github/workflows/conform-pr.yml
@@ -27,9 +27,9 @@ on:
       # - auto_merge_disabled
 
 # Stop pending and in-progress jobs of this workflow.
-# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 env:
@@ -38,7 +38,7 @@ env:
   GOLANGCI_LINT_CACHE: /home/runner/go/cache/lint
   GOMODCACHE: /home/runner/go/mod
   GOPROXY: https://proxy.golang.org
-  CONFORM_TOKEN: ${{ secrets.CONFORM_TOKEN }}  # GITHUB_TOKEN is not enough to query projects, so we use a special one
+  CONFORM_TOKEN: ${{ secrets.CONFORM_TOKEN }} # GITHUB_TOKEN is not enough to query projects, so we use a special one
 
 jobs:
   conform-pr:


### PR DESCRIPTION
The latter is the base reference (in most cases, `main` branch) for `pull_request_target`.
It canceled this workflow for other PRs.