### PR TITLE
Validate collection names

### DIFF
--- a/internal/tests_config.go
+++ b/internal/tests_config.go
@@ -122,8 +122,6 @@ func (tc *TestsConfig) Compare(results *TestResults) (*CompareResult, error) {
 	sort.Strings(tests)
 
 	for _, test := range tests {
-		testRes := results.TestResults[test]
-
 		expectedRes := tc.Default
 		for prefix := test; prefix != ""; prefix = nextPrefix(prefix) {
 			if res, ok := tcMap[prefix]; ok {
@@ -132,15 +130,18 @@ func (tc *TestsConfig) Compare(results *TestResults) (*CompareResult, error) {
 			}
 		}
 
+		testRes := results.TestResults[test]
+		testResOutput := testRes.IndentedOutput()
+
 		switch expectedRes {
 		case Pass:
 			switch testRes.Status {
 			case Pass:
-				compareResult.ExpectedPass[test] = testRes.IndentedOutput()
+				compareResult.ExpectedPass[test] = testResOutput
 			case Skip:
-				compareResult.UnexpectedSkip[test] = testRes.IndentedOutput()
+				compareResult.UnexpectedSkip[test] = testResOutput
 			case Fail:
-				compareResult.UnexpectedFail[test] = testRes.IndentedOutput()
+				compareResult.UnexpectedFail[test] = testResOutput
 			case Unknown:
 				fallthrough
 			default:
@@ -149,11 +150,11 @@ func (tc *TestsConfig) Compare(results *TestResults) (*CompareResult, error) {
 		case Skip:
 			switch testRes.Status {
 			case Pass:
-				compareResult.UnexpectedPass[test] = testRes.IndentedOutput()
+				compareResult.UnexpectedPass[test] = testResOutput
 			case Skip:
-				compareResult.ExpectedSkip[test] = testRes.IndentedOutput()
+				compareResult.ExpectedSkip[test] = testResOutput
 			case Fail:
-				compareResult.UnexpectedFail[test] = testRes.IndentedOutput()
+				compareResult.UnexpectedFail[test] = testResOutput
 			case Unknown:
 				fallthrough
 			default:
@@ -162,11 +163,11 @@ func (tc *TestsConfig) Compare(results *TestResults) (*CompareResult, error) {
 		case Fail:
 			switch testRes.Status {
 			case Pass:
-				compareResult.UnexpectedPass[test] = testRes.IndentedOutput()
+				compareResult.UnexpectedPass[test] = testResOutput
 			case Skip:
-				compareResult.UnexpectedSkip[test] = testRes.IndentedOutput()
+				compareResult.UnexpectedSkip[test] = testResOutput
 			case Fail:
-				compareResult.ExpectedFail[test] = testRes.IndentedOutput()
+				compareResult.ExpectedFail[test] = testResOutput
 			case Unknown:
 				fallthrough
 			default:
@@ -188,7 +189,6 @@ func (tc *TestsConfig) Compare(results *TestResults) (*CompareResult, error) {
 		ExpectedSkip:   len(compareResult.ExpectedSkip),
 		ExpectedPass:   len(compareResult.ExpectedPass),
 	}
-
 	// special case: zero in expected_pass means "don't check"
 	if tc.Stats.ExpectedPass == 0 {
 		tc.Stats.ExpectedPass = compareResult.Stats.ExpectedPass

--- a/tests/diff.yml
+++ b/tests/diff.yml
@@ -12,7 +12,7 @@ results:
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages/FerretDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot/FerretDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash/FerretDB
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length65/FerretDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length255/FerretDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefix/FerretDB
 
     fail:
@@ -23,14 +23,14 @@ results:
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot/MongoDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash/MongoDB
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length65
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length65/MongoDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length255
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length255/MongoDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefix
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefix/MongoDB
 
   mongodb:
     stats:
-      expected_fail: 6
+      expected_fail: 11
       expected_pass: 5
 
     pass:
@@ -43,7 +43,12 @@ results:
     fail:
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages/FerretDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot/FerretDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash/FerretDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length65
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length65/FerretDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefix
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefix/FerretDB

--- a/tests/diff.yml
+++ b/tests/diff.yml
@@ -5,24 +5,44 @@ args: ["-timeout=20s", "-shuffle=on", "-race", "./..."]
 results:
   ferretdb:
     stats:
-      expected_fail: 2
-      expected_pass: 1
+      expected_fail: 7
+      expected_pass: 6
 
     pass:
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages/FerretDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot/FerretDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash/FerretDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length65/FerretDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefixes/_ferretdb_/FerretDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefixes/system/FerretDB
 
     fail:
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages/MongoDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot/MongoDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash/MongoDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length65/MongoDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefixes/_ferretdb_/MongoDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefixes/system/MongoDB
 
   mongodb:
     stats:
-      expected_fail: 2
-      expected_pass: 1
+      expected_fail: 7
+      expected_pass: 6
 
     pass:
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages/MongoDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot/MongoDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash/MongoDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length65/MongoDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefixes/_ferretdb_/MongoDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefixes/system/MongoDB
 
     fail:
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages/FerretDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot/FerretDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash/FerretDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length65/FerretDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefixes/_ferretdb_/FerretDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefixes/system/FerretDB

--- a/tests/diff.yml
+++ b/tests/diff.yml
@@ -5,13 +5,11 @@ args: ["-timeout=20s", "-shuffle=on", "-race", "./..."]
 results:
   ferretdb:
     stats:
-      expected_fail: 11
-      expected_pass: 5
+      expected_fail: 7
+      expected_pass: 3
 
     pass:
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages/FerretDB
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot/FerretDB
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash/FerretDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length255/FerretDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefix/FerretDB
 
@@ -19,10 +17,6 @@ results:
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages/MongoDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot/MongoDB
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash/MongoDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length255
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length255/MongoDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefix
@@ -30,13 +24,11 @@ results:
 
   mongodb:
     stats:
-      expected_fail: 11
-      expected_pass: 5
+      expected_fail: 7
+      expected_pass: 3
 
     pass:
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages/MongoDB
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot/MongoDB
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash/MongoDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length255/MongoDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefix/MongoDB
 
@@ -44,10 +36,6 @@ results:
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages/FerretDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot/FerretDB
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash/FerretDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length255
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length255/FerretDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefix

--- a/tests/diff.yml
+++ b/tests/diff.yml
@@ -31,7 +31,7 @@ results:
       expected_pass: 4
 
     pass:
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length00/MongoDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length200/MongoDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefix/MongoDB
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages/MongoDB
       - github.com/FerretDB/dance/tests/diff/TestNullStrings/MongoDB

--- a/tests/diff.yml
+++ b/tests/diff.yml
@@ -5,38 +5,40 @@ args: ["-timeout=20s", "-shuffle=on", "-race", "./..."]
 results:
   ferretdb:
     stats:
-      expected_fail: 7
-      expected_pass: 6
+      expected_fail: 11
+      expected_pass: 5
 
     pass:
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages/FerretDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot/FerretDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash/FerretDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length65/FerretDB
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefixes/_ferretdb_/FerretDB
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefixes/system/FerretDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefix/FerretDB
 
     fail:
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages/MongoDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot/MongoDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash/MongoDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length65
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length65/MongoDB
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefixes/_ferretdb_/MongoDB
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefixes/system/MongoDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefix
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefix/MongoDB
 
   mongodb:
     stats:
-      expected_fail: 7
-      expected_pass: 6
+      expected_fail: 6
+      expected_pass: 5
 
     pass:
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages/MongoDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot/MongoDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash/MongoDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length65/MongoDB
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefixes/_ferretdb_/MongoDB
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefixes/system/MongoDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefix/MongoDB
 
     fail:
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages
@@ -44,5 +46,4 @@ results:
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot/FerretDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash/FerretDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length65/FerretDB
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefixes/_ferretdb_/FerretDB
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefixes/system/FerretDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefix/FerretDB

--- a/tests/diff.yml
+++ b/tests/diff.yml
@@ -37,7 +37,7 @@ results:
       - github.com/FerretDB/dance/tests/diff/TestErrorMessages/MongoDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot/MongoDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash/MongoDB
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length65/MongoDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length255/MongoDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefix/MongoDB
 
     fail:
@@ -48,7 +48,7 @@ results:
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dot/FerretDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/Dash/FerretDB
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length65
-      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length65/FerretDB
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length255
+      - github.com/FerretDB/dance/tests/diff/TestCollectionName/Length255/FerretDB
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefix
       - github.com/FerretDB/dance/tests/diff/TestCollectionName/ReservedPrefix/FerretDB

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -27,7 +27,8 @@ import (
 //   * dots
 //   * dashes
 //   * max length in FerretDB: 255, in MongoDB: 63.
-//   * FerretDB reserved prefix is _ferretdb_, MongoDB - system..
+//   * FerretDB reserved prefix is _ferretdb_, so FerretDB doesn't allow such prefixes.
+//  MongoDB's reserved prefix is 'system.'. However FerretDB doesn't allow such name because of a dot in it.
 func TestCollectionName(t *testing.T) {
 	t.Parallel()
 

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -44,8 +44,6 @@ func TestCollectionName(t *testing.T) {
 			ctx, db := setup(t)
 			err := db.CreateCollection(ctx, collection)
 			require.NoError(t, err)
-			err = db.Collection(collection).Drop(ctx)
-			require.NoError(t, err)
 		})
 	})
 
@@ -66,8 +64,6 @@ func TestCollectionName(t *testing.T) {
 		t.Run("MongoDB", func(t *testing.T) {
 			ctx, db := setup(t)
 			err := db.CreateCollection(ctx, collection)
-			require.NoError(t, err)
-			err = db.Collection(collection).Drop(ctx)
 			require.NoError(t, err)
 		})
 	})

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -39,6 +39,7 @@ func TestCollectionName(t *testing.T) {
 		collection := strings.Repeat("a", 200)
 
 		t.Run("FerretDB", func(t *testing.T) {
+			_ = db.Collection(collection).Drop(ctx)
 			err := db.CreateCollection(ctx, collection)
 			expected := mongo.CommandError{
 				Name:    "InvalidNamespace",
@@ -60,6 +61,7 @@ func TestCollectionName(t *testing.T) {
 	t.Run("ReservedPrefix", func(t *testing.T) {
 		collection := "_ferretdb_xxx"
 		t.Run("FerretDB", func(t *testing.T) {
+			_ = db.Collection(collection).Drop(ctx)
 			err := db.CreateCollection(ctx, collection)
 			expected := mongo.CommandError{
 				Name:    "InvalidNamespace",

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -23,12 +23,6 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-// TestCollectionName documents difference in responses:
-//   * dots
-//   * dashes
-//   * max length in FerretDB: 255, in MongoDB: 63.
-//   * FerretDB reserved prefix is _ferretdb_, so FerretDB doesn't allow such prefixes.
-//  MongoDB's reserved prefix is 'system.'. However FerretDB doesn't allow such name because of a dot in it.
 func TestCollectionName(t *testing.T) {
 	t.Parallel()
 

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -33,6 +33,7 @@ func TestCollectionName(t *testing.T) {
 
 	ctx, db := setup(t)
 	db = db.Client().Database("admin")
+	dbName := db.Name()
 
 	t.Run("Dot", func(t *testing.T) {
 		collection := "collection_name_with_a_dot."
@@ -42,7 +43,7 @@ func TestCollectionName(t *testing.T) {
 			expected := mongo.CommandError{
 				Name:    "InvalidNamespace",
 				Code:    73,
-				Message: fmt.Sprintf(`Invalid collection name: 'testcollectionname-err.%s'`, collection),
+				Message: fmt.Sprintf(`Invalid collection name: '%s.%s'`, dbName, collection),
 			}
 			AssertEqualError(t, expected, err)
 			err = db.Collection(collection).Drop(ctx)
@@ -65,7 +66,7 @@ func TestCollectionName(t *testing.T) {
 			expected := mongo.CommandError{
 				Name:    "InvalidNamespace",
 				Code:    73,
-				Message: fmt.Sprintf(`Invalid collection name: 'testcollectionname-err.%s'`, collection),
+				Message: fmt.Sprintf(`Invalid collection name: '%s.%s'`, dbName, collection),
 			}
 			AssertEqualError(t, expected, err)
 		})
@@ -86,7 +87,7 @@ func TestCollectionName(t *testing.T) {
 			expected := mongo.CommandError{
 				Name:    "InvalidNamespace",
 				Code:    73,
-				Message: fmt.Sprintf(`Invalid collection name: 'testcollectionname-err.%s'`, collection),
+				Message: fmt.Sprintf(`Invalid collection name: '%s.%s'`, dbName, collection),
 			}
 			AssertEqualError(t, expected, err)
 		})
@@ -107,7 +108,7 @@ func TestCollectionName(t *testing.T) {
 				expected := mongo.CommandError{
 					Name:    "InvalidNamespace",
 					Code:    73,
-					Message: fmt.Sprintf(`Invalid collection name: 'testcollectionname-err.%s'`, collection),
+					Message: fmt.Sprintf(`Invalid collection name: '%s.%s'`, dbName, collection),
 				}
 				AssertEqualError(t, expected, err)
 			})

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -31,7 +31,6 @@ func TestCollectionName(t *testing.T) {
 		dbName := db.Name()
 		collection := strings.Repeat("a", 200)
 		t.Run("FerretDB", func(t *testing.T) {
-			_ = db.Collection(collection).Drop(ctx)
 			err := db.CreateCollection(ctx, collection)
 			expected := mongo.CommandError{
 				Name:    "InvalidNamespace",
@@ -42,7 +41,6 @@ func TestCollectionName(t *testing.T) {
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
-			_ = db.Collection(collection).Drop(ctx)
 			err := db.CreateCollection(ctx, collection)
 			require.NoError(t, err)
 			err = db.Collection(collection).Drop(ctx)
@@ -55,7 +53,6 @@ func TestCollectionName(t *testing.T) {
 		dbName := db.Name()
 		collection := "_ferretdb_xxx"
 		t.Run("FerretDB", func(t *testing.T) {
-			_ = db.Collection(collection).Drop(ctx)
 			err := db.CreateCollection(ctx, collection)
 			expected := mongo.CommandError{
 				Name:    "InvalidNamespace",
@@ -66,7 +63,6 @@ func TestCollectionName(t *testing.T) {
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
-			_ = db.Collection(collection).Drop(ctx)
 			err := db.CreateCollection(ctx, collection)
 			require.NoError(t, err)
 			err = db.Collection(collection).Drop(ctx)

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -49,7 +49,6 @@ func TestCollectionName(t *testing.T) {
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
-			_ = db.Collection(collection).Drop(ctx)
 			err := db.CreateCollection(ctx, collection)
 			require.NoError(t, err)
 			err = db.Collection(collection).Drop(ctx)
@@ -70,7 +69,6 @@ func TestCollectionName(t *testing.T) {
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
-			_ = db.Collection(collection).Drop(ctx)
 			err := db.CreateCollection(ctx, collection)
 			require.NoError(t, err)
 			err = db.Collection(collection).Drop(ctx)

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -51,6 +51,7 @@ func TestCollectionName(t *testing.T) {
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
+			_ = db.Collection(collection).Drop(ctx)
 			err := db.CreateCollection(ctx, collection)
 			require.NoError(t, err)
 			err = db.Collection(collection).Drop(ctx)

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -84,7 +84,6 @@ func TestCollectionName(t *testing.T) {
 
 		t.Run("FerretDB", func(t *testing.T) {
 			err := db.CreateCollection(ctx, collection)
-			require.NoError(t, err)
 			expected := mongo.CommandError{
 				Name:    "InvalidNamespace",
 				Code:    73,

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -78,24 +78,25 @@ func TestCollectionName(t *testing.T) {
 		})
 	})
 
-	t.Run("Length65", func(t *testing.T) {
-		collection := strings.Repeat("a", 65)
+	t.Run("Length121", func(t *testing.T) {
+		collection := strings.Repeat("a", 121)
 
 		t.Run("FerretDB", func(t *testing.T) {
-			err := db.CreateCollection(ctx, collection)
-			require.NoError(t, err)
-			err = db.Collection(collection).Drop(ctx)
-			require.NoError(t, err)
-		})
-
-		t.Run("MongoDB", func(t *testing.T) {
 			err := db.CreateCollection(ctx, collection)
 			expected := mongo.CommandError{
 				Name:    "InvalidNamespace",
 				Code:    73,
 				Message: fmt.Sprintf(`Invalid collection name: 'testcollectionname-err.%s'`, collection),
 			}
+
 			require.Equal(t, expected, err)
+		})
+
+		t.Run("MongoDB", func(t *testing.T) {
+			err := db.CreateCollection(ctx, collection)
+			require.NoError(t, err)
+			err = db.Collection(collection).Drop(ctx)
+			require.NoError(t, err)
 		})
 	})
 

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -72,7 +72,6 @@ func TestCollectionName(t *testing.T) {
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
-			_ = db.Collection(collection).Drop(ctx)
 			err := db.CreateCollection(ctx, collection)
 			require.NoError(t, err)
 			err = db.Collection(collection).Drop(ctx)
@@ -94,7 +93,6 @@ func TestCollectionName(t *testing.T) {
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
-			_ = db.Collection(collection).Drop(ctx)
 			err := db.CreateCollection(ctx, collection)
 			require.NoError(t, err)
 			err = db.Collection(collection).Drop(ctx)
@@ -115,7 +113,6 @@ func TestCollectionName(t *testing.T) {
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
-			_ = db.Collection(collection).Drop(ctx)
 			err := db.CreateCollection(ctx, collection)
 			require.NoError(t, err)
 			err = db.Collection(collection).Drop(ctx)

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -23,7 +23,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-// TestCollectionName documents difference in reposnes:
+// TestCollectionName documents difference in responses:
 //   * dots
 //   * dashes
 //   * max length in FerretDB: 255, in MongoDB: 63.

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -27,10 +27,10 @@ func TestCollectionName(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Length200", func(t *testing.T) {
-		ctx, db := setup(t)
-		dbName := db.Name()
 		collection := strings.Repeat("a", 200)
 		t.Run("FerretDB", func(t *testing.T) {
+			ctx, db := setup(t)
+			dbName := db.Name()
 			err := db.CreateCollection(ctx, collection)
 			expected := mongo.CommandError{
 				Name:    "InvalidNamespace",
@@ -41,6 +41,7 @@ func TestCollectionName(t *testing.T) {
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
+			ctx, db := setup(t)
 			err := db.CreateCollection(ctx, collection)
 			require.NoError(t, err)
 			err = db.Collection(collection).Drop(ctx)
@@ -49,10 +50,10 @@ func TestCollectionName(t *testing.T) {
 	})
 
 	t.Run("ReservedPrefix", func(t *testing.T) {
-		ctx, db := setup(t)
-		dbName := db.Name()
 		collection := "_ferretdb_xxx"
 		t.Run("FerretDB", func(t *testing.T) {
+			ctx, db := setup(t)
+			dbName := db.Name()
 			err := db.CreateCollection(ctx, collection)
 			expected := mongo.CommandError{
 				Name:    "InvalidNamespace",
@@ -63,6 +64,7 @@ func TestCollectionName(t *testing.T) {
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
+			ctx, db := setup(t)
 			err := db.CreateCollection(ctx, collection)
 			require.NoError(t, err)
 			err = db.Collection(collection).Drop(ctx)

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 // TestCollectionName documents difference in reposnes:
@@ -39,12 +39,20 @@ func TestCollectionName(t *testing.T) {
 
 		t.Run("FerretDB", func(t *testing.T) {
 			err := db.CreateCollection(ctx, collection)
-			expected := fmt.Errorf(`Invalid collection name: 'testcollectionname-err.collection_name_with_a-dot.'`)
-			assert.Equal(t, expected, err)
+			expected := mongo.CommandError{
+				Name:    "InvalidNamespace",
+				Code:    73,
+				Message: fmt.Sprintf(`Invalid collection name: 'testcollectionname-err.%s'`, collection),
+			}
+			require.Equal(t, expected, err)
+			err = db.Collection(collection).Drop(ctx)
+			require.NoError(t, err)
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
 			err := db.CreateCollection(ctx, collection)
+			require.NoError(t, err)
+			err = db.Collection(collection).Drop(ctx)
 			require.NoError(t, err)
 		})
 	})
@@ -54,12 +62,18 @@ func TestCollectionName(t *testing.T) {
 
 		t.Run("FerretDB", func(t *testing.T) {
 			err := db.CreateCollection(ctx, collection)
-			expected := fmt.Errorf(`Invalid collection name: 'testcollectionname-err.collection_name_with_a-dash'`)
-			assert.Equal(t, expected, err)
+			expected := mongo.CommandError{
+				Name:    "InvalidNamespace",
+				Code:    73,
+				Message: fmt.Sprintf(`Invalid collection name: 'testcollectionname-err.%s'`, collection),
+			}
+			require.Equal(t, expected, err)
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
 			err := db.CreateCollection(ctx, collection)
+			require.NoError(t, err)
+			err = db.Collection(collection).Drop(ctx)
 			require.NoError(t, err)
 		})
 	})
@@ -70,12 +84,18 @@ func TestCollectionName(t *testing.T) {
 		t.Run("FerretDB", func(t *testing.T) {
 			err := db.CreateCollection(ctx, collection)
 			require.NoError(t, err)
+			err = db.Collection(collection).Drop(ctx)
+			require.NoError(t, err)
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
 			err := db.CreateCollection(ctx, collection)
-			expected := fmt.Errorf(`Invalid collection name: 'testcollectionname-err.%s'`, collection)
-			assert.Equal(t, expected, err)
+			expected := mongo.CommandError{
+				Name:    "InvalidNamespace",
+				Code:    73,
+				Message: fmt.Sprintf(`Invalid collection name: 'testcollectionname-err.%s'`, collection),
+			}
+			require.Equal(t, expected, err)
 		})
 	})
 
@@ -84,12 +104,18 @@ func TestCollectionName(t *testing.T) {
 		t.Run("_ferretdb_", func(t *testing.T) {
 			t.Run("FerretDB", func(t *testing.T) {
 				err := db.CreateCollection(ctx, collection)
-				expected := fmt.Errorf(`Invalid collection name: 'testcollectionname-err.%s'`, collection)
-				assert.Equal(t, expected, err)
+				expected := mongo.CommandError{
+					Name:    "InvalidNamespace",
+					Code:    73,
+					Message: fmt.Sprintf(`Invalid collection name: 'testcollectionname-err.%s'`, collection),
+				}
+				require.Equal(t, expected, err)
 			})
 
 			t.Run("MongoDB", func(t *testing.T) {
 				err := db.CreateCollection(ctx, collection)
+				require.NoError(t, err)
+				err = db.Collection(collection).Drop(ctx)
 				require.NoError(t, err)
 			})
 		})
@@ -99,12 +125,18 @@ func TestCollectionName(t *testing.T) {
 			t.Run("FerretDB", func(t *testing.T) {
 				err := db.CreateCollection(ctx, collection)
 				require.NoError(t, err)
+				err = db.Collection(collection).Drop(ctx)
+				require.NoError(t, err)
 			})
 
 			t.Run("MongoDB", func(t *testing.T) {
 				err := db.CreateCollection(ctx, collection)
-				expected := fmt.Errorf(`Invalid collection name: 'testcollectionname-err.%s'`, collection)
-				assert.Equal(t, expected, err)
+				expected := mongo.CommandError{
+					Name:    "InvalidNamespace",
+					Code:    73,
+					Message: "Invalid system namespace: admin.system.",
+				}
+				require.Equal(t, expected, err)
 			})
 		})
 	})

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -44,7 +44,7 @@ func TestCollectionName(t *testing.T) {
 				Code:    73,
 				Message: fmt.Sprintf(`Invalid collection name: 'testcollectionname-err.%s'`, collection),
 			}
-			require.Equal(t, expected, err)
+			AssertEqualError(t, expected, err)
 			err = db.Collection(collection).Drop(ctx)
 			require.NoError(t, err)
 		})
@@ -67,7 +67,7 @@ func TestCollectionName(t *testing.T) {
 				Code:    73,
 				Message: fmt.Sprintf(`Invalid collection name: 'testcollectionname-err.%s'`, collection),
 			}
-			require.Equal(t, expected, err)
+			AssertEqualError(t, expected, err)
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
@@ -88,8 +88,7 @@ func TestCollectionName(t *testing.T) {
 				Code:    73,
 				Message: fmt.Sprintf(`Invalid collection name: 'testcollectionname-err.%s'`, collection),
 			}
-
-			require.Equal(t, expected, err)
+			AssertEqualError(t, expected, err)
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
@@ -110,7 +109,7 @@ func TestCollectionName(t *testing.T) {
 					Code:    73,
 					Message: fmt.Sprintf(`Invalid collection name: 'testcollectionname-err.%s'`, collection),
 				}
-				require.Equal(t, expected, err)
+				AssertEqualError(t, expected, err)
 			})
 
 			t.Run("MongoDB", func(t *testing.T) {
@@ -137,7 +136,7 @@ func TestCollectionName(t *testing.T) {
 					Code:    73,
 					Message: "Invalid system namespace: admin.system.",
 				}
-				require.Equal(t, expected, err)
+				AssertEqualError(t, expected, err)
 			})
 		})
 	})

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -72,6 +72,7 @@ func TestCollectionName(t *testing.T) {
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
+			_ = db.Collection(collection).Drop(ctx)
 			err := db.CreateCollection(ctx, collection)
 			require.NoError(t, err)
 			err = db.Collection(collection).Drop(ctx)
@@ -113,6 +114,7 @@ func TestCollectionName(t *testing.T) {
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
+			_ = db.Collection(collection).Drop(ctx)
 			err := db.CreateCollection(ctx, collection)
 			require.NoError(t, err)
 			err = db.Collection(collection).Drop(ctx)

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -81,7 +81,7 @@ func TestCollectionName(t *testing.T) {
 	})
 
 	t.Run("Length255", func(t *testing.T) {
-		collection := strings.Repeat("a", 255)
+		collection := strings.Repeat("a", 249)
 
 		t.Run("FerretDB", func(t *testing.T) {
 			err := db.CreateCollection(ctx, collection)
@@ -94,6 +94,7 @@ func TestCollectionName(t *testing.T) {
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
+			_ = db.Collection(collection).Drop(ctx)
 			err := db.CreateCollection(ctx, collection)
 			require.NoError(t, err)
 			err = db.Collection(collection).Drop(ctx)

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -100,8 +100,8 @@ func TestCollectionName(t *testing.T) {
 	})
 
 	t.Run("ReservedPrefixes", func(t *testing.T) {
-		collection := "_ferretdb_xxx"
 		t.Run("_ferretdb_", func(t *testing.T) {
+			collection := "_ferretdb_xxx"
 			t.Run("FerretDB", func(t *testing.T) {
 				err := db.CreateCollection(ctx, collection)
 				expected := mongo.CommandError{
@@ -120,8 +120,8 @@ func TestCollectionName(t *testing.T) {
 			})
 		})
 
-		collection = "system."
 		t.Run("system", func(t *testing.T) {
+			collection := "system."
 			t.Run("FerretDB", func(t *testing.T) {
 				err := db.CreateCollection(ctx, collection)
 				require.NoError(t, err)

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -1,0 +1,111 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diff
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCollectionName documents difference in reposnes:
+//   * dots
+//   * dashes
+//   * max length in FerretDB: 255, in MongoDB: 63.
+//   * FerretDB reserved prefix is _ferretdb_, MongoDB - system..
+func TestCollectionName(t *testing.T) {
+	t.Parallel()
+
+	ctx, db := setup(t)
+	db = db.Client().Database("admin")
+
+	t.Run("Dot", func(t *testing.T) {
+		collection := "collection_name_with_a_dot."
+
+		t.Run("FerretDB", func(t *testing.T) {
+			err := db.CreateCollection(ctx, collection)
+			expected := fmt.Errorf(`Invalid collection name: 'testcollectionname-err.collection_name_with_a-dot.'`)
+			assert.Equal(t, expected, err)
+		})
+
+		t.Run("MongoDB", func(t *testing.T) {
+			err := db.CreateCollection(ctx, collection)
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("Dash", func(t *testing.T) {
+		collection := "collection_name_with_a-dash"
+
+		t.Run("FerretDB", func(t *testing.T) {
+			err := db.CreateCollection(ctx, collection)
+			expected := fmt.Errorf(`Invalid collection name: 'testcollectionname-err.collection_name_with_a-dash'`)
+			assert.Equal(t, expected, err)
+		})
+
+		t.Run("MongoDB", func(t *testing.T) {
+			err := db.CreateCollection(ctx, collection)
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("Length65", func(t *testing.T) {
+		collection := strings.Repeat("a", 65)
+
+		t.Run("FerretDB", func(t *testing.T) {
+			err := db.CreateCollection(ctx, collection)
+			require.NoError(t, err)
+		})
+
+		t.Run("MongoDB", func(t *testing.T) {
+			err := db.CreateCollection(ctx, collection)
+			expected := fmt.Errorf(`Invalid collection name: 'testcollectionname-err.%s'`, collection)
+			assert.Equal(t, expected, err)
+		})
+	})
+
+	t.Run("ReservedPrefixes", func(t *testing.T) {
+		collection := "_ferretdb_xxx"
+		t.Run("_ferretdb_", func(t *testing.T) {
+			t.Run("FerretDB", func(t *testing.T) {
+				err := db.CreateCollection(ctx, collection)
+				expected := fmt.Errorf(`Invalid collection name: 'testcollectionname-err.%s'`, collection)
+				assert.Equal(t, expected, err)
+			})
+
+			t.Run("MongoDB", func(t *testing.T) {
+				err := db.CreateCollection(ctx, collection)
+				require.NoError(t, err)
+			})
+		})
+
+		collection = "system."
+		t.Run("system", func(t *testing.T) {
+			t.Run("FerretDB", func(t *testing.T) {
+				err := db.CreateCollection(ctx, collection)
+				require.NoError(t, err)
+			})
+
+			t.Run("MongoDB", func(t *testing.T) {
+				err := db.CreateCollection(ctx, collection)
+				expected := fmt.Errorf(`Invalid collection name: 'testcollectionname-err.%s'`, collection)
+				assert.Equal(t, expected, err)
+			})
+		})
+	})
+}

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -72,6 +72,7 @@ func TestCollectionName(t *testing.T) {
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
+			_ = db.Collection(collection).Drop(ctx)
 			err := db.CreateCollection(ctx, collection)
 			require.NoError(t, err)
 			err = db.Collection(collection).Drop(ctx)
@@ -93,6 +94,7 @@ func TestCollectionName(t *testing.T) {
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
+			_ = db.Collection(collection).Drop(ctx)
 			err := db.CreateCollection(ctx, collection)
 			require.NoError(t, err)
 			err = db.Collection(collection).Drop(ctx)
@@ -113,6 +115,7 @@ func TestCollectionName(t *testing.T) {
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
+			_ = db.Collection(collection).Drop(ctx)
 			err := db.CreateCollection(ctx, collection)
 			require.NoError(t, err)
 			err = db.Collection(collection).Drop(ctx)

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -59,7 +59,7 @@ func TestCollectionName(t *testing.T) {
 	})
 
 	t.Run("Dash", func(t *testing.T) {
-		collection := "collection_name_with_a-dash"
+		collection := "a-dash"
 
 		t.Run("FerretDB", func(t *testing.T) {
 			err := db.CreateCollection(ctx, collection)
@@ -79,26 +79,25 @@ func TestCollectionName(t *testing.T) {
 		})
 	})
 
-	t.Run("Length65", func(t *testing.T) {
-		collection := strings.Repeat("a", 65)
+	t.Run("Length255", func(t *testing.T) {
+		collection := strings.Repeat("a", 255)
 
 		t.Run("FerretDB", func(t *testing.T) {
-			_ = db.Collection(collection).Drop(ctx)
-
 			err := db.CreateCollection(ctx, collection)
 			require.NoError(t, err)
-			err = db.Collection(collection).Drop(ctx)
-			require.NoError(t, err)
-		})
-
-		t.Run("MongoDB", func(t *testing.T) {
-			err := db.CreateCollection(ctx, collection)
 			expected := mongo.CommandError{
 				Name:    "InvalidNamespace",
 				Code:    73,
 				Message: fmt.Sprintf(`Invalid collection name: '%s.%s'`, dbName, collection),
 			}
 			AssertEqualError(t, expected, err)
+		})
+
+		t.Run("MongoDB", func(t *testing.T) {
+			err := db.CreateCollection(ctx, collection)
+			require.NoError(t, err)
+			err = db.Collection(collection).Drop(ctx)
+			require.NoError(t, err)
 		})
 	})
 

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -33,54 +33,7 @@ func TestCollectionName(t *testing.T) {
 	t.Parallel()
 
 	ctx, db := setup(t)
-	db = db.Client().Database("admin")
 	dbName := db.Name()
-
-	t.Run("Dot", func(t *testing.T) {
-		collection := "collection_name_with_a_dot."
-
-		t.Run("FerretDB", func(t *testing.T) {
-			err := db.CreateCollection(ctx, collection)
-			expected := mongo.CommandError{
-				Name:    "InvalidNamespace",
-				Code:    73,
-				Message: fmt.Sprintf(`Invalid collection name: '%s.%s'`, dbName, collection),
-			}
-			AssertEqualError(t, expected, err)
-			err = db.Collection(collection).Drop(ctx)
-			require.NoError(t, err)
-		})
-
-		t.Run("MongoDB", func(t *testing.T) {
-			_ = db.Collection(collection).Drop(ctx)
-			err := db.CreateCollection(ctx, collection)
-			require.NoError(t, err)
-			err = db.Collection(collection).Drop(ctx)
-			require.NoError(t, err)
-		})
-	})
-
-	t.Run("Dash", func(t *testing.T) {
-		collection := "a-dash"
-
-		t.Run("FerretDB", func(t *testing.T) {
-			err := db.CreateCollection(ctx, collection)
-			expected := mongo.CommandError{
-				Name:    "InvalidNamespace",
-				Code:    73,
-				Message: fmt.Sprintf(`Invalid collection name: '%s.%s'`, dbName, collection),
-			}
-			AssertEqualError(t, expected, err)
-		})
-
-		t.Run("MongoDB", func(t *testing.T) {
-			_ = db.Collection(collection).Drop(ctx)
-			err := db.CreateCollection(ctx, collection)
-			require.NoError(t, err)
-			err = db.Collection(collection).Drop(ctx)
-			require.NoError(t, err)
-		})
-	})
 
 	t.Run("Length255", func(t *testing.T) {
 		collection := strings.Repeat("a", 249)

--- a/tests/diff/collection_name_test.go
+++ b/tests/diff/collection_name_test.go
@@ -26,12 +26,10 @@ import (
 func TestCollectionName(t *testing.T) {
 	t.Parallel()
 
-	ctx, db := setup(t)
-	dbName := db.Name()
-
 	t.Run("Length200", func(t *testing.T) {
+		ctx, db := setup(t)
+		dbName := db.Name()
 		collection := strings.Repeat("a", 200)
-
 		t.Run("FerretDB", func(t *testing.T) {
 			_ = db.Collection(collection).Drop(ctx)
 			err := db.CreateCollection(ctx, collection)
@@ -53,6 +51,8 @@ func TestCollectionName(t *testing.T) {
 	})
 
 	t.Run("ReservedPrefix", func(t *testing.T) {
+		ctx, db := setup(t)
+		dbName := db.Name()
 		collection := "_ferretdb_xxx"
 		t.Run("FerretDB", func(t *testing.T) {
 			_ = db.Collection(collection).Drop(ctx)

--- a/tests/diff/error_messages_test.go
+++ b/tests/diff/error_messages_test.go
@@ -38,15 +38,22 @@ func TestErrorMessages(t *testing.T) {
 
 	t.Run("FerretDB", func(t *testing.T) {
 		// our error message is better
-		expected := `BSON field 'allParameters' is the wrong type 'string', ` +
-			`expected types '[bool, long, int, decimal, double]'`
-		assert.Equal(t, expected, actual.Message)
+		expected := mongo.CommandError{
+			Code:    14,
+			Name:    "TypeMismatch",
+			Message: "BSON field 'allParameters' is the wrong type 'string', expected types '[bool, long, int, decimal, double]'",
+		}
+		AssertEqualError(t, expected, actual)
 	})
 
 	t.Run("MongoDB", func(t *testing.T) {
 		// closing single quote is in the wrong place
-		expected := `BSON field 'getParameter.allParameters' is the wrong type 'string', ` +
-			`expected types '[bool, long, int, decimal, double']`
-		assert.Equal(t, expected, actual.Message)
+		expected := mongo.CommandError{
+			Code: 14,
+			Name: "TypeMismatch",
+			Message: "BSON field 'getParameter.allParameters' is the wrong type 'string', " +
+				"expected types '[bool, long, int, decimal, double']",
+		}
+		AssertEqualError(t, expected, actual)
 	})
 }

--- a/tests/diff/helpers.go
+++ b/tests/diff/helpers.go
@@ -1,0 +1,39 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// AssertEqualError asserts that the expected error is the same as the actual (ignoring the Raw part).
+func AssertEqualError(t testing.TB, expected mongo.CommandError, actual error) bool {
+	t.Helper()
+
+	a, ok := actual.(mongo.CommandError)
+	if !ok {
+		return assert.Equal(t, expected, actual)
+	}
+
+	// set expected fields that might be helpful in the test output
+	require.Nil(t, expected.Raw)
+	expected.Raw = a.Raw
+
+	return assert.Equal(t, expected, a)
+}

--- a/tests/diff/null_strings_test.go
+++ b/tests/diff/null_strings_test.go
@@ -31,9 +31,7 @@ func TestNullStrings(t *testing.T) {
 	})
 
 	t.Run("FerretDB", func(t *testing.T) {
-		if err == nil {
-			t.FailNow()
-		}
+		require.Error(t, err)
 		assert.Regexp(t, "^.* unsupported Unicode escape sequence .*$", err.Error())
 	})
 

--- a/tests/diff/null_strings_test.go
+++ b/tests/diff/null_strings_test.go
@@ -31,6 +31,9 @@ func TestNullStrings(t *testing.T) {
 	})
 
 	t.Run("FerretDB", func(t *testing.T) {
+		if err == nil {
+			t.FailNow()
+		}
 		assert.Regexp(t, "^.* unsupported Unicode escape sequence .*$", err.Error())
 	})
 

--- a/tests/diff/null_strings_test.go
+++ b/tests/diff/null_strings_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 )
 


### PR DESCRIPTION
Closes FerretDB/FerretDB#806.

| Case | FerretDB | MongoDB | Status | 
|--|--|--|--| 
| `system.` |  fails: `system.` contains a dot |  fails: `system.` is a reserved prefix | skipped as both fail | 
| `_ferretdb_` | fails: `_ferretdb_` is a reserved prefix | pass | added | 
|  max length | 120  | 255 |  added | 
|  dots | fail | pass |  added | 
|  dashes | fail | pass |  added | 


Corresponding FerretDB PR [#844](https://github.com/FerretDB/FerretDB/pull/844).