### PR TITLE
Don't support nested arrays

### DIFF
--- a/tests/diff.yml
+++ b/tests/diff.yml
@@ -6,7 +6,7 @@ results:
   ferretdb:
     stats:
       expected_fail: 24
-      expected_pass: 8
+      expected_pass: 10
 
     pass:
       - regex: FerretDB$
@@ -17,7 +17,7 @@ results:
   mongodb:
     stats:
       expected_fail: 24
-      expected_pass: 8
+      expected_pass: 10
 
     pass:
       - regex: MongoDB$

--- a/tests/diff.yml
+++ b/tests/diff.yml
@@ -5,7 +5,7 @@ args: ["-timeout=30s", "-shuffle=on", "-race", "./..."]
 results:
   ferretdb:
     stats:
-      expected_fail: 19
+      expected_fail: 24
       expected_pass: 8
 
     pass:
@@ -16,7 +16,7 @@ results:
 
   mongodb:
     stats:
-      expected_fail: 19
+      expected_fail: 24
       expected_pass: 8
 
     pass:

--- a/tests/diff/document_validation_test.go
+++ b/tests/diff/document_validation_test.go
@@ -38,7 +38,7 @@ func TestDocumentValidation(t *testing.T) {
 			expected := mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
-				Message: `invalid key: "foo$" (key must not contain '$' sign).`,
+				Message: `invalid key: "foo$" (key must not contain '$' sign)`,
 			}
 			AssertEqualError(t, expected, err)
 		})
@@ -69,7 +69,7 @@ func TestDocumentValidation(t *testing.T) {
 			expected := mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
-				Message: `invalid key: "foo$" (key must not contain '$' sign).`,
+				Message: `invalid key: "foo$" (key must not contain '$' sign)`,
 			}
 			AssertEqualError(t, expected, err)
 		})

--- a/tests/diff/document_validation_test.go
+++ b/tests/diff/document_validation_test.go
@@ -38,7 +38,7 @@ func TestDocumentValidation(t *testing.T) {
 			expected := mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
-				Message: `Invalid document, reason: invalid key: "foo$" (key must not contain $).`,
+				Message: `invalid key: \"foo$\" (key must not contain '$' sign).`,
 			}
 			AssertEqualError(t, expected, err)
 		})
@@ -69,7 +69,7 @@ func TestDocumentValidation(t *testing.T) {
 			expected := mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
-				Message: `Invalid document, reason: invalid key: "foo$" (key must not contain $).`,
+				Message: `invalid key: \"foo$\" (key must not contain '$' sign).`,
 			}
 			AssertEqualError(t, expected, err)
 		})

--- a/tests/diff/document_validation_test.go
+++ b/tests/diff/document_validation_test.go
@@ -38,7 +38,7 @@ func TestDocumentValidation(t *testing.T) {
 			expected := mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
-				Message: `invalid key: \"foo$\" (key must not contain '$' sign).`,
+				Message: `invalid key: "foo$" (key must not contain '$' sign).`,
 			}
 			AssertEqualError(t, expected, err)
 		})
@@ -69,7 +69,7 @@ func TestDocumentValidation(t *testing.T) {
 			expected := mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
-				Message: `invalid key: \"foo$\" (key must not contain '$' sign).`,
+				Message: `invalid key: "foo$" (key must not contain '$' sign).`,
 			}
 			AssertEqualError(t, expected, err)
 		})

--- a/tests/diff/nested_arrays_test.go
+++ b/tests/diff/nested_arrays_test.go
@@ -69,7 +69,7 @@ func TestNestedArrays(t *testing.T) {
 			expected := mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
-				Message: `invalid value: { "foo": [ [ "bar" ] ] } (nested arrays are not allowed)`,
+				Message: `invalid value: { "foo": [ [ "bar" ] ] } (nested arrays are not supported)`,
 			}
 			AssertEqualError(t, expected, err)
 		})

--- a/tests/diff/nested_arrays_test.go
+++ b/tests/diff/nested_arrays_test.go
@@ -38,7 +38,7 @@ func TestNestedArrays(t *testing.T) {
 			expected := mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
-				Message: `invalid value: { foo: [["bar"]] } (nested arrays are not allowed)`,
+				Message: `invalid value: { "foo": [ [ "bar" ] ] } (nested arrays are not allowed)`,
 			}
 			AssertEqualError(t, expected, err)
 		})
@@ -69,7 +69,7 @@ func TestNestedArrays(t *testing.T) {
 			expected := mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
-				Message: `invalid value: { foo: [["bar"]] } (nested arrays are not allowed)`,
+				Message: `invalid value: { "foo": [ [ "bar" ] ] } (nested arrays are not allowed)`,
 			}
 			AssertEqualError(t, expected, err)
 		})

--- a/tests/diff/nested_arrays_test.go
+++ b/tests/diff/nested_arrays_test.go
@@ -1,0 +1,83 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func TestNestedArrays(t *testing.T) {
+	t.Parallel()
+
+	ctx, db := setup(t)
+
+	t.Run("Insert", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := db.Collection("arrays-insert").InsertOne(ctx, bson.D{{"foo", bson.A{bson.A{"bar"}}}})
+
+		t.Run("FerretDB", func(t *testing.T) {
+			t.Parallel()
+
+			expected := mongo.CommandError{
+				Code:    2,
+				Name:    "BadValue",
+				Message: `invalid value: { foo: [["bar"]] } (nested arrays are not allowed)`,
+			}
+			AssertEqualError(t, expected, err)
+		})
+
+		t.Run("MongoDB", func(t *testing.T) {
+			t.Parallel()
+
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		t.Parallel()
+
+		// initiate a collection with a valid document, so we have something to update
+		collection := db.Collection("arrays-update")
+		_, err := collection.InsertOne(ctx, bson.D{
+			{"_id", "valid"},
+			{"v", int32(42)},
+		})
+		require.NoError(t, err)
+
+		_, err = collection.UpdateOne(ctx, bson.D{}, bson.D{{"$set", bson.D{{"foo", bson.A{bson.A{"bar"}}}}}})
+
+		t.Run("FerretDB", func(t *testing.T) {
+			t.Parallel()
+
+			expected := mongo.CommandError{
+				Code:    2,
+				Name:    "BadValue",
+				Message: `invalid value: { foo: [["bar"]] } (nested arrays are not allowed)`,
+			}
+			AssertEqualError(t, expected, err)
+		})
+
+		t.Run("MongoDB", func(t *testing.T) {
+			t.Parallel()
+
+			require.NoError(t, err)
+		})
+	})
+}

--- a/tests/diff/nested_arrays_test.go
+++ b/tests/diff/nested_arrays_test.go
@@ -38,7 +38,7 @@ func TestNestedArrays(t *testing.T) {
 			expected := mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
-				Message: `invalid value: { "foo": [ [ "bar" ] ] } (nested arrays are not allowed)`,
+				Message: `invalid value: { "foo": [ [ "bar" ] ] } (nested arrays are not supported)`,
 			}
 			AssertEqualError(t, expected, err)
 		})


### PR DESCRIPTION
Refs [#1305](https://github.com/FerretDB/FerretDB/issues/1305).

Plus two tests to pass: one for insert and one for update.
Plus five tests to fail: 
- `TestNestedArrays  Insert`'s subtest
- `TestNestedArrays  Insert` itself
- `TestNestedArrays  Update`'s subtest
- `TestNestedArrays  Update` itself
- `TestNestedArrays`.