### PR TITLE
Add `debugError` diff tests

### DIFF
--- a/tests/diff.yml
+++ b/tests/diff.yml
@@ -5,7 +5,7 @@ args: ["-timeout=30s", "-shuffle=on", "-race", "./..."]
 results:
   ferretdb:
     stats:
-      expected_fail: 44
+      expected_fail: 45
       expected_pass: 19
 
     pass:
@@ -16,7 +16,7 @@ results:
 
   mongodb:
     stats:
-      expected_fail: 44
+      expected_fail: 45
       expected_pass: 19
 
     pass:

--- a/tests/diff.yml
+++ b/tests/diff.yml
@@ -5,8 +5,8 @@ args: ["-timeout=30s", "-shuffle=on", "-race", "./..."]
 results:
   ferretdb:
     stats:
-      expected_fail: 32
-      expected_pass: 13
+      expected_fail: 43
+      expected_pass: 18
 
     pass:
       - regex: FerretDB$
@@ -16,8 +16,8 @@ results:
 
   mongodb:
     stats:
-      expected_fail: 32
-      expected_pass: 13
+      expected_fail: 43
+      expected_pass: 18
 
     pass:
       - regex: MongoDB$

--- a/tests/diff.yml
+++ b/tests/diff.yml
@@ -5,8 +5,8 @@ args: ["-timeout=30s", "-shuffle=on", "-race", "./..."]
 results:
   ferretdb:
     stats:
-      expected_fail: 43
-      expected_pass: 18
+      expected_fail: 44
+      expected_pass: 19
 
     pass:
       - regex: FerretDB$
@@ -16,8 +16,8 @@ results:
 
   mongodb:
     stats:
-      expected_fail: 43
-      expected_pass: 18
+      expected_fail: 44
+      expected_pass: 19
 
     pass:
       - regex: MongoDB$

--- a/tests/diff/debug_error_test.go
+++ b/tests/diff/debug_error_test.go
@@ -58,6 +58,15 @@ func TestDebugError(t *testing.T) {
 				Message: "ErrorCode(33333)",
 			},
 		},
+		// TODO: https://github.com/FerretDB/dance/issues/249
+		//"panic": {
+		//	input: "panic",
+		//	expectedErr: &mongo.CommandError{
+		//		Code:    0,
+		//		Message: "connection(127.0.0.1:27017[-22]) socket was unexpectedly closed: EOF",
+		//		Labels:  []string{"NetworkError"},
+		//	},
+		//},
 		"string": {
 			input: "foo",
 			expectedErr: &mongo.CommandError{
@@ -69,10 +78,10 @@ func TestDebugError(t *testing.T) {
 	} {
 		name, tc := name, tc
 
-		ctx, db := setup(t)
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+
+			ctx, db := setup(t)
 			var actual bson.D
 			err := db.RunCommand(ctx, bson.D{{"debugError", tc.input}}).Decode(&actual)
 

--- a/tests/diff/debug_error_test.go
+++ b/tests/diff/debug_error_test.go
@@ -30,14 +30,14 @@ func TestDebugError(t *testing.T) {
 		expectedErr *mongo.CommandError
 		expectedRes bson.D
 	}{
-		//"empty": {
-		//	input: "",
-		//	expectedErr: &mongo.CommandError{
-		//		Code:    1,
-		//		Name:    "InternalError",
-		//		Message: "Unset",
-		//	},
-		//},
+		"empty": {
+			input: "",
+			expectedErr: &mongo.CommandError{
+				Code:    1,
+				Name:    "InternalError",
+				Message: "command failed",
+			},
+		},
 		"ok": {
 			input:       "ok",
 			expectedRes: bson.D{{"ok", float64(1)}},

--- a/tests/diff/debug_error_test.go
+++ b/tests/diff/debug_error_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package diff
 
 import (
@@ -63,13 +77,11 @@ func TestDebugError(t *testing.T) {
 			err := db.RunCommand(ctx, bson.D{{"debugError", tc.input}}).Decode(&actual)
 
 			t.Run("FerretDB", func(t *testing.T) {
-
 				if tc.expectedErr != nil {
 					AssertEqualError(t, *tc.expectedErr, err)
 					return
 				}
 				assert.NoError(t, err)
-
 				assert.Equal(t, tc.expectedRes, actual)
 			})
 
@@ -84,5 +96,4 @@ func TestDebugError(t *testing.T) {
 			})
 		})
 	}
-
 }

--- a/tests/diff/debug_error_test.go
+++ b/tests/diff/debug_error_test.go
@@ -11,8 +11,6 @@ import (
 func TestDebugError(t *testing.T) {
 	t.Parallel()
 
-	ctx, db := setup(t)
-
 	for name, tc := range map[string]struct {
 		input       string
 		expectedErr *mongo.CommandError
@@ -57,8 +55,10 @@ func TestDebugError(t *testing.T) {
 	} {
 		name, tc := name, tc
 
+		ctx, db := setup(t)
+
 		t.Run(name, func(t *testing.T) {
-			//t.Parallel()
+			t.Parallel()
 			var actual bson.D
 			err := db.RunCommand(ctx, bson.D{{"debugError", tc.input}}).Decode(&actual)
 
@@ -71,6 +71,16 @@ func TestDebugError(t *testing.T) {
 				assert.NoError(t, err)
 
 				assert.Equal(t, tc.expectedRes, actual)
+			})
+
+			t.Run("MongoDB", func(t *testing.T) {
+				expectedErr := mongo.CommandError{
+					Code:    59,
+					Message: "no such command: 'debugError'",
+					Name:    "CommandNotFound",
+				}
+
+				AssertEqualError(t, expectedErr, err)
 			})
 		})
 	}

--- a/tests/diff/debug_error_test.go
+++ b/tests/diff/debug_error_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 func TestDebugError(t *testing.T) {
@@ -14,41 +15,62 @@ func TestDebugError(t *testing.T) {
 
 	for name, tc := range map[string]struct {
 		input       string
-		expectedErr error
+		expectedErr *mongo.CommandError
 		expectedRes bson.D
 	}{
 		"ok": {
-			input: "ok",
-		},
-		"panic": {
-			input: "panic",
+			input:       "ok",
+			expectedRes: bson.D{{"ok", float64(1)}},
 		},
 		"codeZero": {
 			input: "0",
+			expectedErr: &mongo.CommandError{
+				Code:    1,
+				Name:    "InternalError",
+				Message: "Unset",
+			},
 		},
 		"codeOne": {
 			input: "1",
+			expectedErr: &mongo.CommandError{
+				Code:    1,
+				Name:    "InternalError",
+				Message: "InternalError",
+			},
 		},
 		"codeNotLabeled": {
 			input: "33333",
+			expectedErr: &mongo.CommandError{
+				Code:    1,
+				Name:    "InternalError",
+				Message: "ErrorCode(33333)",
+			},
+		},
+		"string": {
+			input: "foo",
+			expectedErr: &mongo.CommandError{
+				Code:    1,
+				Name:    "InternalError",
+				Message: "foo",
+			},
 		},
 	} {
 		name, tc := name, tc
 
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
+			//t.Parallel()
 			var actual bson.D
 			err := db.RunCommand(ctx, bson.D{{"debugError", tc.input}}).Decode(&actual)
 
 			t.Run("FerretDB", func(t *testing.T) {
+
 				if tc.expectedErr != nil {
-					assert.Equal(t, tc.expectedErr, err)
+					AssertEqualError(t, *tc.expectedErr, err)
 					return
 				}
 				assert.NoError(t, err)
 
 				assert.Equal(t, tc.expectedRes, actual)
-
 			})
 		})
 	}

--- a/tests/diff/debug_error_test.go
+++ b/tests/diff/debug_error_test.go
@@ -1,0 +1,56 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestDebugError(t *testing.T) {
+	t.Parallel()
+
+	ctx, db := setup(t)
+
+	for name, tc := range map[string]struct {
+		input       string
+		expectedErr error
+		expectedRes bson.D
+	}{
+		"ok": {
+			input: "ok",
+		},
+		"panic": {
+			input: "panic",
+		},
+		"codeZero": {
+			input: "0",
+		},
+		"codeOne": {
+			input: "1",
+		},
+		"codeNotLabeled": {
+			input: "33333",
+		},
+	} {
+		name, tc := name, tc
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var actual bson.D
+			err := db.RunCommand(ctx, bson.D{{"debugError", tc.input}}).Decode(&actual)
+
+			t.Run("FerretDB", func(t *testing.T) {
+				if tc.expectedErr != nil {
+					assert.Equal(t, tc.expectedErr, err)
+					return
+				}
+				assert.NoError(t, err)
+
+				assert.Equal(t, tc.expectedRes, actual)
+
+			})
+		})
+	}
+
+}

--- a/tests/diff/debug_error_test.go
+++ b/tests/diff/debug_error_test.go
@@ -30,6 +30,14 @@ func TestDebugError(t *testing.T) {
 		expectedErr *mongo.CommandError
 		expectedRes bson.D
 	}{
+		//"empty": {
+		//	input: "",
+		//	expectedErr: &mongo.CommandError{
+		//		Code:    1,
+		//		Name:    "InternalError",
+		//		Message: "Unset",
+		//	},
+		//},
 		"ok": {
 			input:       "ok",
 			expectedRes: bson.D{{"ok", float64(1)}},

--- a/tests/diff/document_validation_test.go
+++ b/tests/diff/document_validation_test.go
@@ -100,10 +100,11 @@ func TestDocumentValidation(t *testing.T) {
 			name, tc := name, tc
 
 			t.Run(name, func(t *testing.T) {
-				t.Parallel()
+				// TODO: make them parallel https://github.com/FerretDB/FerretDB/
+				//t.Parallel()
 
 				// initiate a collection with a valid document, so we have something to update
-				collection := db.Collection("update-validation" + name)
+				collection := db.Collection("update-validation-" + name)
 				_, err := collection.InsertOne(ctx, bson.D{
 					{"_id", "valid"},
 					{"v", int32(42)},

--- a/tests/diff/document_validation_test.go
+++ b/tests/diff/document_validation_test.go
@@ -100,7 +100,7 @@ func TestDocumentValidation(t *testing.T) {
 			name, tc := name, tc
 
 			t.Run(name, func(t *testing.T) {
-				// TODO: make them parallel https://github.com/FerretDB/FerretDB/
+				// TODO: make them run in parallel https://github.com/FerretDB/FerretDB/issues/1488
 				//t.Parallel()
 
 				// initiate a collection with a valid document, so we have something to update


### PR DESCRIPTION
Closes FerretDB/FerretDB#640.

This PR introduces tests for a new `debugError` command, but it also temporary fixes one failing test that was pushed to the main branch because of the recent bug that made dance flaky.