### PR TITLE
Duplicate keys are not allowed in `insert` documents

### DIFF
--- a/tests/diff.yml
+++ b/tests/diff.yml
@@ -5,8 +5,8 @@ args: ["-timeout=30s", "-shuffle=on", "-race", "./..."]
 results:
   ferretdb:
     stats:
-      expected_fail: 30
-      expected_pass: 12
+      expected_fail: 32
+      expected_pass: 13
 
     pass:
       - regex: FerretDB$
@@ -16,8 +16,8 @@ results:
 
   mongodb:
     stats:
-      expected_fail: 30
-      expected_pass: 12
+      expected_fail: 32
+      expected_pass: 13
 
     pass:
       - regex: MongoDB$

--- a/tests/diff/insert_test.go
+++ b/tests/diff/insert_test.go
@@ -48,5 +48,4 @@ func TestInsertDuplicateKeys(t *testing.T) {
 
 		require.NoError(t, err)
 	})
-
 }

--- a/tests/diff/insert_test.go
+++ b/tests/diff/insert_test.go
@@ -1,0 +1,52 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func TestInsertDuplicateKeys(t *testing.T) {
+	t.Parallel()
+
+	ctx, db := setup(t)
+
+	doc := bson.D{{"_id", "duplicate_keys"}, {"foo", "bar"}, {"foo", "baz"}}
+
+	_, err := db.Collection("insert-duplicate-keys").InsertOne(ctx, doc)
+
+	t.Run("FerretDB", func(t *testing.T) {
+		t.Parallel()
+
+		expected := mongo.CommandError{
+			Code:    2,
+			Name:    "BadValue",
+			Message: `invalid key: "foo" (duplicate keys are not allowed)`,
+		}
+
+		AssertEqualError(t, expected, err)
+	})
+
+	t.Run("MongoDB", func(t *testing.T) {
+		t.Parallel()
+
+		require.NoError(t, err)
+	})
+
+}


### PR DESCRIPTION
When insert command is called, insert documents must not have duplicate keys.

Refs https://github.com/FerretDB/FerretDB/issues/1263.
Depends on https://github.com/FerretDB/FerretDB/pull/1391.