### PR TITLE
Allow `-` in database names

### DIFF
--- a/tests/diff.yml
+++ b/tests/diff.yml
@@ -5,8 +5,8 @@ args: ["-timeout=30s", "-shuffle=on", "-race", "./..."]
 results:
   ferretdb:
     stats:
-      expected_fail: 51
-      expected_pass: 21
+      expected_fail: 49
+      expected_pass: 20
 
     pass:
       - regex: FerretDB$
@@ -16,8 +16,8 @@ results:
 
   mongodb:
     stats:
-      expected_fail: 51
-      expected_pass: 21
+      expected_fail: 49
+      expected_pass: 20
 
     pass:
       - regex: MongoDB$

--- a/tests/diff/names_test.go
+++ b/tests/diff/names_test.go
@@ -48,27 +48,6 @@ func TestDatabaseName(t *testing.T) {
 			db.Client().Database(dbName).Drop(ctx)
 		})
 	})
-
-	t.Run("Dashes", func(t *testing.T) {
-		dbName := "ferretdb-xxx"
-		ctx, db := setup(t)
-		err := db.Client().Database(dbName).CreateCollection(ctx, collectionName)
-
-		t.Run("FerretDB", func(t *testing.T) {
-			expected := mongo.CommandError{
-				Name:    "InvalidNamespace",
-				Code:    73,
-				Message: fmt.Sprintf(`Invalid namespace: %s.%s`, dbName, collectionName),
-			}
-			alt := fmt.Sprintf(`Invalid namespace: %s.%s`, dbName, collectionName)
-			AssertEqualAltError(t, expected, alt, err)
-		})
-
-		t.Run("MongoDB", func(t *testing.T) {
-			require.NoError(t, err)
-			db.Client().Database(dbName).Drop(ctx)
-		})
-	})
 }
 
 func TestCollectionName(t *testing.T) {


### PR DESCRIPTION
After [#1582](https://github.com/FerretDB/FerretDB/pull/1582).

Closes [#1321](https://github.com/FerretDB/FerretDB/issues/1321).