### PR TITLE
Do not handle `no ci` in one job

### DIFF
--- a/.github/workflows/conform-pr.yml
+++ b/.github/workflows/conform-pr.yml
@@ -44,7 +44,8 @@ jobs:
     runs-on: ubuntu-20.04
 
     # No `trust` label check because we don't checkout PR's code.
-    if: github.event_name != 'pull_request_target' || !contains(github.event.pull_request.labels.*.name, 'no ci')
+    # No `no ci` label to prevent accidental auto-merges: jobs skipped with `if` conditional are considered successful.
+    if: github.event_name != 'pull_request_target'
 
     steps:
       # Warning! Be careful about changing the steps here as it might cause some security problems


### PR DESCRIPTION
See FerretDB/github-actions#122.