### PR TITLE
Show the problem with dance checking errors

### DIFF
--- a/tests/diff/insert_test.go
+++ b/tests/diff/insert_test.go
@@ -49,3 +49,37 @@ func TestInsertDuplicateKeys(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestInsertArrays(t *testing.T) {
+	t.Parallel()
+
+	ctx, db := setup(t)
+
+	doc := bson.D{{"_id", bson.A{"foo"}}}
+
+	_, err := db.Collection("insert-arrays").InsertOne(ctx, doc)
+
+	t.Run("FerretDB", func(t *testing.T) {
+		t.Parallel()
+
+		expected := mongo.CommandError{
+			Code:    2,
+			Name:    "BadValue",
+			Message: `The '_id' value cannot be of type array`,
+		}
+
+		assertEqualError(t, expected, err)
+	})
+
+	t.Run("MongoDB", func(t *testing.T) {
+		t.Parallel()
+
+		expected := mongo.CommandError{
+			Code:    2,
+			Name:    "BadValue",
+			Message: `The '_id' value cannot be of type array`,
+		}
+
+		assertEqualError(t, expected, err)
+	})
+}


### PR DESCRIPTION
**Do not merge this PR!**

This PR demonstrates that dance doesn't check errors correctly.

It's not correct to use `mongo.CommandError` as expected error, this is not what MongoDB returns:

```
task env-up DB=mongod
...


task dance DB=mongodb TEST=diff
task: [dance] go run ../cmd/dance -db=mongodb diff
Waiting for port 27017 to be up...
Run configurations: [diff.yml]
diff.yml (diff)
Unexpectedly failed tests:
github.com/FerretDB/dance/tests/diff/TestInsertArrays/MongoDB:
	=== RUN   TestInsertArrays/MongoDB
	=== PAUSE TestInsertArrays/MongoDB
	=== CONT  TestInsertArrays/MongoDB
	    insert_test.go:83:
	        	Error Trace:	/Users/elena/workdir/dance/tests/diff/helpers.go:75
	        	            				/Users/elena/workdir/dance/tests/diff/insert_test.go:83
	        	Error:      	Not equal:
	        	            	expected: mongo.CommandError(mongo.CommandError{Code:2, Message:"The '_id' value cannot be of type array", Labels:[]string(nil), Name:"BadValue", Wrapped:error(nil), Raw:bson.Raw(nil)})
	        	            	actual  : mongo.WriteException(mongo.WriteException{WriteConcernError:(*mongo.WriteConcernError)(nil), WriteErrors:mongo.WriteErrors{mongo.WriteError{Index:0, Code:53, Message:"The '_id' value cannot be of type array", Details:bson.Raw(nil), Raw:bson.Raw{0x4e, 0x0, 0x0, 0x0, 0x10, 0x69, 0x6e, 0x64, 0x65, 0x78, 0x0, 0x0, 0x0, 0x0, 0x0, 0x10, 0x63, 0x6f, 0x64, 0x65, 0x0, 0x35, 0x0, 0x0, 0x0, 0x2, 0x65, 0x72, 0x72, 0x6d, 0x73, 0x67, 0x0, 0x28, 0x0, 0x0, 0x0, 0x54, 0x68, 0x65, 0x20, 0x27, 0x5f, 0x69, 0x64, 0x27, 0x20, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x20, 0x63, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x20, 0x62, 0x65, 0x20, 0x6f, 0x66, 0x20, 0x74, 0x79, 0x70, 0x65, 0x20, 0x61, 0x72, 0x72, 0x61, 0x79, 0x0, 0x0}}}, Labels:[]string(nil), Raw:bson.Raw{0x7b, 0x0, 0x0, 0x0, 0x10, 0x6e, 0x0, 0x0, 0x0, 0x0, 0x0, 0x4, 0x77, 0x72, 0x69, 0x74, 0x65, 0x45, 0x72, 0x72, 0x6f, 0x72, 0x73, 0x0, 0x56, 0x0, 0x0, 0x0, 0x3, 0x30, 0x0, 0x4e, 0x0, 0x0, 0x0, 0x10, 0x69, 0x6e, 0x64, 0x65, 0x78, 0x0, 0x0, 0x0, 0x0, 0x0, 0x10, 0x63, 0x6f, 0x64, 0x65, 0x0, 0x35, 0x0, 0x0, 0x0, 0x2, 0x65, 0x72, 0x72, 0x6d, 0x73, 0x67, 0x0, 0x28, 0x0, 0x0, 0x0, 0x54, 0x68, 0x65, 0x20, 0x27, 0x5f, 0x69, 0x64, 0x27, 0x20, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x20, 0x63, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x20, 0x62, 0x65, 0x20, 0x6f, 0x66, 0x20, 0x74, 0x79, 0x70, 0x65, 0x20, 0x61, 0x72, 0x72, 0x61, 0x79, 0x0, 0x0, 0x0, 0x1, 0x6f, 0x6b, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f, 0x0}})
	        	Test:       	TestInsertArrays/MongoDB
	    --- FAIL: TestInsertArrays/MongoDB (0.00s)
```