### PR TITLE
Fix type of error that need to be checked for `insert`

### DIFF
--- a/tests/diff/helpers.go
+++ b/tests/diff/helpers.go
@@ -111,3 +111,33 @@ func assertEqualAltError(t testing.TB, expected mongo.CommandError, altMessage s
 	expected.Message = altMessage
 	return assert.Equal(t, expected, a)
 }
+
+// unsetRaw returns error with all Raw fields unset. It returns nil if err is nil.
+//
+// Error is checked using a regular type assertion; wrapped errors (errors.As) are not checked.
+func unsetRaw(t testing.TB, err error) error {
+	t.Helper()
+
+	switch err := err.(type) {
+	case mongo.CommandError:
+		err.Raw = nil
+		return err
+
+	case mongo.WriteException:
+		if err.WriteConcernError != nil {
+			err.WriteConcernError.Raw = nil
+		}
+
+		wes := make([]mongo.WriteError, len(err.WriteErrors))
+		for i, we := range err.WriteErrors {
+			we.Raw = nil
+			wes[i] = we
+		}
+		err.WriteErrors = wes
+		err.Raw = nil
+		return err
+
+	default:
+		return err
+	}
+}

--- a/tests/diff/helpers.go
+++ b/tests/diff/helpers.go
@@ -118,7 +118,7 @@ func assertEqualAltError(t testing.TB, expected mongo.CommandError, altMessage s
 func unsetRaw(t testing.TB, err error) error {
 	t.Helper()
 
-	switch err := err.(type) {
+	switch err := err.(type) { //nolint:errorlint // simple check is enough
 	case mongo.CommandError:
 		err.Raw = nil
 		return err
@@ -129,12 +129,15 @@ func unsetRaw(t testing.TB, err error) error {
 		}
 
 		wes := make([]mongo.WriteError, len(err.WriteErrors))
+
 		for i, we := range err.WriteErrors {
 			we.Raw = nil
 			wes[i] = we
 		}
+
 		err.WriteErrors = wes
 		err.Raw = nil
+
 		return err
 
 	default:

--- a/tests/diff/insert_test.go
+++ b/tests/diff/insert_test.go
@@ -15,11 +15,12 @@
 package diff
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
-	"testing"
 )
 
 func TestInsertDuplicateKeys(t *testing.T) {

--- a/tests/diff/insert_test.go
+++ b/tests/diff/insert_test.go
@@ -16,7 +16,8 @@ package diff
 
 import (
 	"testing"
-
+	
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -34,13 +35,13 @@ func TestInsertDuplicateKeys(t *testing.T) {
 	t.Run("FerretDB", func(t *testing.T) {
 		t.Parallel()
 
-		expected := mongo.CommandError{
+		expected := mongo.WriteException{WriteErrors: []mongo.WriteError{{
+			Index:   0,
 			Code:    2,
-			Name:    "BadValue",
 			Message: `invalid key: "foo" (duplicate keys are not allowed)`,
-		}
+		}}}
 
-		assertEqualError(t, expected, err)
+		assert.Equal(t, expected, unsetRaw(t, err))
 	})
 
 	t.Run("MongoDB", func(t *testing.T) {

--- a/tests/diff/insert_test.go
+++ b/tests/diff/insert_test.go
@@ -15,12 +15,11 @@
 package diff
 
 import (
-	"testing"
-	
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"testing"
 )
 
 func TestInsertDuplicateKeys(t *testing.T) {

--- a/tests/diff/nested_arrays_test.go
+++ b/tests/diff/nested_arrays_test.go
@@ -17,6 +17,7 @@ package diff
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -35,12 +36,13 @@ func TestNestedArrays(t *testing.T) {
 		t.Run("FerretDB", func(t *testing.T) {
 			t.Parallel()
 
-			expected := mongo.CommandError{
+			expected := mongo.WriteException{WriteErrors: []mongo.WriteError{{
+				Index:   0,
 				Code:    2,
-				Name:    "BadValue",
 				Message: `invalid value: { "foo": [ [ "bar" ] ] } (nested arrays are not supported)`,
-			}
-			assertEqualError(t, expected, err)
+			}}}
+
+			assert.Equal(t, expected, unsetRaw(t, err))
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {


### PR DESCRIPTION
In the case of the `insert` operation, the error that should be returned is `mongo.WriteException`, not `mongo.CommandError`.

It was fixed in FerretDB here - https://github.com/FerretDB/FerretDB/pull/1673, and diff tests need to be fixed too.