### PR TITLE
`$mul` returns validation error on unsupported +INF result

### DIFF
--- a/tests/diff.yml
+++ b/tests/diff.yml
@@ -5,8 +5,8 @@ args: ["-timeout=30s", "-shuffle=on", "-race", "./..."]
 results:
   ferretdb:
     stats:
-      expected_fail: 53
-      expected_pass: 22
+      expected_fail: 56
+      expected_pass: 23
 
     pass:
       - regex: FerretDB$
@@ -16,8 +16,8 @@ results:
 
   mongodb:
     stats:
-      expected_fail: 53
-      expected_pass: 22
+      expected_fail: 56
+      expected_pass: 23
 
     pass:
       - regex: MongoDB$

--- a/tests/diff.yml
+++ b/tests/diff.yml
@@ -5,8 +5,8 @@ args: ["-timeout=30s", "-shuffle=on", "-race", "./..."]
 results:
   ferretdb:
     stats:
-      expected_fail: 56
-      expected_pass: 23
+      expected_fail: 61
+      expected_pass: 25
 
     pass:
       - regex: FerretDB$
@@ -16,8 +16,8 @@ results:
 
   mongodb:
     stats:
-      expected_fail: 56
-      expected_pass: 23
+      expected_fail: 61
+      expected_pass: 25
 
     pass:
       - regex: MongoDB$

--- a/tests/diff.yml
+++ b/tests/diff.yml
@@ -5,7 +5,7 @@ args: ["-timeout=30s", "-shuffle=on", "-race", "./..."]
 results:
   ferretdb:
     stats:
-      expected_fail: 61
+      expected_fail: 63
       expected_pass: 25
 
     pass:
@@ -16,7 +16,7 @@ results:
 
   mongodb:
     stats:
-      expected_fail: 61
+      expected_fail: 63
       expected_pass: 25
 
     pass:

--- a/tests/diff/float_values_test.go
+++ b/tests/diff/float_values_test.go
@@ -100,9 +100,10 @@ func TestFloatValues(t *testing.T) {
 				insert: bson.D{{"_id", "number"}, {"v", int32(42)}},
 				update: bson.D{{"$mul", bson.D{{"v", math.MaxFloat64}}}},
 				expected: mongo.CommandError{
-					Code:    2,
-					Name:    "BadValue",
-					Message: `invalid value: { "v": +Inf } (infinity values are not allowed)`,
+					Code: 2,
+					Name: "BadValue",
+					Message: `update produces invalid value: { "v": +Inf }` +
+						` (update operations that produce infinity values are not allowed)`,
 				},
 			},
 		} {

--- a/tests/diff/float_values_test.go
+++ b/tests/diff/float_values_test.go
@@ -93,7 +93,7 @@ func TestFloatValues(t *testing.T) {
 		expected := math.Copysign(0.0, +1)
 
 		// testify require equates -0 == 0 so this passes for both -0 and 0.
-		require.Equal(t, 0, actual)
+		require.Equal(t, expected, actual)
 
 		t.Run("FerretDB", func(t *testing.T) {
 			t.Parallel()
@@ -104,7 +104,7 @@ func TestFloatValues(t *testing.T) {
 		t.Run("MongoDB", func(t *testing.T) {
 			t.Parallel()
 
-			require.Equal(t, math.Signbit(expected), math.Signbit(actual))
+			require.NotEqual(t, math.Signbit(expected), math.Signbit(actual))
 		})
 	})
 
@@ -225,7 +225,7 @@ func TestFloatValues(t *testing.T) {
 				t.Run("MongoDB", func(t *testing.T) {
 					t.Parallel()
 
-					require.Equal(t, math.Signbit(expected), math.Signbit(actual))
+					require.NotEqual(t, math.Signbit(expected), math.Signbit(actual))
 				})
 			})
 		}

--- a/tests/diff/float_values_test.go
+++ b/tests/diff/float_values_test.go
@@ -90,21 +90,19 @@ func TestFloatValues(t *testing.T) {
 			}
 		}
 
-		expected := math.Copysign(0.0, +1)
-
 		// testify require equates -0 == 0 so this passes for both -0 and 0.
-		require.Equal(t, expected, actual)
+		require.Equal(t, 0.0, actual)
 
 		t.Run("FerretDB", func(t *testing.T) {
 			t.Parallel()
 
-			require.Equal(t, math.Signbit(expected), math.Signbit(actual))
+			require.Equal(t, math.Signbit(math.Copysign(0.0, +1)), math.Signbit(actual))
 		})
 
 		t.Run("MongoDB", func(t *testing.T) {
 			t.Parallel()
 
-			require.NotEqual(t, math.Signbit(expected), math.Signbit(actual))
+			require.Equal(t, math.Signbit(math.Copysign(0.0, -1)), math.Signbit(actual))
 		})
 	})
 
@@ -210,22 +208,20 @@ func TestFloatValues(t *testing.T) {
 						require.True(t, ok)
 					}
 				}
-
-				expected := math.Copysign(0.0, +1)
-
+				
 				// testify require equates -0 == 0 so this passes for both -0 and 0.
-				require.Equal(t, expected, actual)
+				require.Equal(t, 0.0, actual)
 
 				t.Run("FerretDB", func(t *testing.T) {
 					t.Parallel()
 
-					require.Equal(t, math.Signbit(expected), math.Signbit(actual))
+					require.Equal(t, math.Signbit(math.Copysign(0.0, +1)), math.Signbit(actual))
 				})
 
 				t.Run("MongoDB", func(t *testing.T) {
 					t.Parallel()
 
-					require.NotEqual(t, math.Signbit(expected), math.Signbit(actual))
+					require.Equal(t, math.Signbit(math.Copysign(0.0, -1)), math.Signbit(actual))
 				})
 			})
 		}

--- a/tests/diff/float_values_test.go
+++ b/tests/diff/float_values_test.go
@@ -86,7 +86,7 @@ func TestFloatValues(t *testing.T) {
 
 	})*/
 
-	t.Run("FindAndModify", func(t *testing.T) {
+	t.Run("UpdateOne", func(t *testing.T) {
 		t.Parallel()
 
 		for name, tc := range map[string]struct {
@@ -96,8 +96,8 @@ func TestFloatValues(t *testing.T) {
 			expected mongo.CommandError
 		}{
 			"MulMaxFloat64": {
-				filter: bson.D{{"_id", "1"}},
-				insert: bson.D{{"_id", "1"}, {"v", int32(42)}},
+				filter: bson.D{{"_id", "number"}},
+				insert: bson.D{{"_id", "number"}, {"v", int32(42)}},
 				update: bson.D{{"$mul", bson.D{{"v", math.MaxFloat64}}}},
 				expected: mongo.CommandError{
 					Code:    2,
@@ -111,12 +111,11 @@ func TestFloatValues(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
 
-				collection := db.Collection("update-mul-" + name)
+				collection := db.Collection("update-one-" + name)
 				_, err := collection.InsertOne(ctx, tc.insert)
 				require.NoError(t, err)
 
-				var update bson.D
-				err = collection.FindOneAndUpdate(ctx, tc.filter, tc.update).Decode(update)
+				_, err = collection.UpdateOne(ctx, tc.filter, tc.update)
 
 				t.Run("FerretDB", func(t *testing.T) {
 					t.Parallel()

--- a/tests/diff/negative_zero_test.go
+++ b/tests/diff/negative_zero_test.go
@@ -66,7 +66,7 @@ func TestNegativeZero(t *testing.T) {
 		})
 	})
 
-	t.Run("UpdateOneNegativeZero", func(t *testing.T) {
+	t.Run("UpdateOne", func(t *testing.T) {
 		t.Parallel()
 
 		for name, tc := range map[string]struct {

--- a/tests/diff/negative_zero_test.go
+++ b/tests/diff/negative_zero_test.go
@@ -1,0 +1,132 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diff
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestNegativeZero(t *testing.T) {
+	t.Parallel()
+
+	ctx, db := setup(t)
+
+	t.Run("Insert", func(t *testing.T) {
+		t.Parallel()
+
+		filter := bson.D{{"_id", "1"}}
+		doc := bson.D{{"_id", "1"}, {"foo", math.Copysign(0.0, -1)}}
+
+		collection := db.Collection("insert-negative-zero")
+		_, err := collection.InsertOne(ctx, doc)
+		require.NoError(t, err)
+
+		var res bson.D
+		err = collection.FindOne(ctx, filter).Decode(&res)
+		require.NoError(t, err)
+
+		var actual float64
+		for _, e := range res {
+			if e.Key == "foo" {
+				var ok bool
+				actual, ok = e.Value.(float64)
+				require.True(t, ok)
+			}
+		}
+
+		// testify require equates -0 == 0 so this passes for both -0 and 0.
+		require.Equal(t, 0.0, actual)
+
+		t.Run("FerretDB", func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, math.Signbit(math.Copysign(0.0, +1)), math.Signbit(actual))
+		})
+
+		t.Run("MongoDB", func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, math.Signbit(math.Copysign(0.0, -1)), math.Signbit(actual))
+		})
+	})
+
+	t.Run("UpdateOneNegativeZero", func(t *testing.T) {
+		t.Parallel()
+
+		for name, tc := range map[string]struct {
+			insert any
+			update any
+			id     string
+		}{
+			"ZeroMulNegative": {
+				id:     "zero",
+				insert: int32(0),
+				update: float64(-1),
+			},
+			"NegativeMulZero": {
+				id:     "negative",
+				insert: int64(-1),
+				update: float64(0),
+			},
+		} {
+			name, tc := name, tc
+
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+
+				filter := bson.D{{"_id", tc.id}}
+
+				collection := db.Collection("update-negative-zero-" + name)
+				_, err := collection.InsertOne(ctx, bson.D{{"_id", tc.id}, {"v", tc.insert}})
+				require.NoError(t, err)
+
+				_, err = collection.UpdateOne(ctx, filter, bson.D{{"$mul", bson.D{{"v", tc.update}}}})
+				require.NoError(t, err)
+
+				var res bson.D
+				err = collection.FindOne(ctx, filter).Decode(&res)
+				require.NoError(t, err)
+
+				var actual float64
+				for _, e := range res {
+					if e.Key == "v" {
+						var ok bool
+						actual, ok = e.Value.(float64)
+						require.True(t, ok)
+					}
+				}
+
+				// testify require equates -0 == 0 so this passes for both -0 and 0.
+				require.Equal(t, 0.0, actual)
+
+				t.Run("FerretDB", func(t *testing.T) {
+					t.Parallel()
+
+					require.Equal(t, math.Signbit(math.Copysign(0.0, +1)), math.Signbit(actual))
+				})
+
+				t.Run("MongoDB", func(t *testing.T) {
+					t.Parallel()
+
+					require.Equal(t, math.Signbit(math.Copysign(0.0, -1)), math.Signbit(actual))
+				})
+			})
+		}
+	})
+}

--- a/tests/diff/update_test.go
+++ b/tests/diff/update_test.go
@@ -23,25 +23,29 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-func TestFloatValues(t *testing.T) {
+func TestUpdateProduceInfinity(t *testing.T) {
 	t.Parallel()
 
 	ctx, db := setup(t)
 
-	t.Run("Insert", func(t *testing.T) {
+	t.Run("UpdateOne", func(t *testing.T) {
 		t.Parallel()
 
 		for name, tc := range map[string]struct {
-			doc      bson.D
+			filter   bson.D
+			insert   bson.D
+			update   bson.D
 			expected mongo.CommandError
 		}{
-			"NaN": {
-				doc: bson.D{{"_id", "1"}, {"foo", math.NaN()}},
+			"Mul": {
+				filter: bson.D{{"_id", "number"}},
+				insert: bson.D{{"_id", "number"}, {"v", int32(42)}},
+				update: bson.D{{"$mul", bson.D{{"v", math.MaxFloat64}}}},
 				expected: mongo.CommandError{
 					Code: 2,
 					Name: "BadValue",
-					Message: `wire.OpMsg.Document: validation failed for { insert: "insert-NaN", ordered: true, ` +
-						`$db: "testfloatvalues", documents: [ { _id: "1", foo: nan.0 } ] } with: NaN is not supported`,
+					Message: `update produces invalid value: { "v": +Inf }` +
+						` (update operations that produce infinity values are not allowed)`,
 				},
 			},
 		} {
@@ -50,7 +54,11 @@ func TestFloatValues(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
 
-				_, err := db.Collection("insert-"+name).InsertOne(ctx, tc.doc)
+				collection := db.Collection("update-one-" + name)
+				_, err := collection.InsertOne(ctx, tc.insert)
+				require.NoError(t, err)
+
+				_, err = collection.UpdateOne(ctx, tc.filter, tc.update)
 
 				t.Run("FerretDB", func(t *testing.T) {
 					t.Parallel()
@@ -66,14 +74,4 @@ func TestFloatValues(t *testing.T) {
 			})
 		}
 	})
-
-	// TODO https://github.com/FerretDB/dance/issues/266
-	/*t.Run("Update", func(t *testing.T) {
-
-	})*/
-
-	// TODO https://github.com/FerretDB/dance/issues/266
-	/*t.Run("FindAndModify", func(t *testing.T) {
-
-	})*/
 }

--- a/tests/diff/update_test.go
+++ b/tests/diff/update_test.go
@@ -37,7 +37,7 @@ func TestUpdateProduceInfinity(t *testing.T) {
 			update   bson.D
 			expected mongo.CommandError
 		}{
-			"Mul": {
+			"MulInf": {
 				filter: bson.D{{"_id", "number"}},
 				insert: bson.D{{"_id", "number"}, {"v", int32(42)}},
 				update: bson.D{{"$mul", bson.D{{"v", math.MaxFloat64}}}},

--- a/tests/mongo.yml
+++ b/tests/mongo.yml
@@ -1,22 +1,97 @@
 ---
 runner: jstest
 args:
+  - mongo/jstests/core/all*.js
+  - mongo/jstests/core/auth[1-2].js
+  - mongo/jstests/core/array[1-4].js
+  - mongo/jstests/core/arrayfind[1-9].js
   - mongo/jstests/core/basic*.js
-  - mongo/jstests/auth/auth1.js
+  - mongo/jstests/core/find_and_modify.js
+  - mongo/jstests/core/find_and_modify[2-4].js
+  - mongo/jstests/core/uniqueness.js
+  - mongo/jstests/core/unset*.js
+  - mongo/jstests/core/update[2-9].js
+  - mongo/jstests/core/update[a-z].js
 
 results:
   ferretdb:
     stats:
-      expected_fail: 2
-      expected_pass: 7
+      expected_fail: 34
+      expected_pass: 20
     fail:
+      # https://docs.ferretdb.io/diff/
+      # 3. FerretDB does not support nested arrays.
+      - mongo/jstests/core/all.js
+      - mongo/jstests/core/all2.js
+      - mongo/jstests/core/all4.js
+      - mongo/jstests/core/all5.js
+      - mongo/jstests/core/array1.js
+      - mongo/jstests/core/arrayfind1.js
+      - mongo/jstests/core/arrayfind2.js
+      - mongo/jstests/core/arrayfind4.js
+
+      # https://github.com/FerretDB/FerretDB/issues/1724
+      - mongo/jstests/core/arrayfind5.js
+
       # https://github.com/FerretDB/FerretDB/issues/161
       - mongo/jstests/core/basic1.js
-      - mongo/jstests/auth/auth1.js
 
+      # https://github.com/FerretDB/FerretDB/issues/1710
+      # https://github.com/FerretDB/FerretDB/issues/731
+      - mongo/jstests/core/arrayfind3.js
+      - mongo/jstests/core/arrayfind6.js
+      - mongo/jstests/core/arrayfind7.js
+      - mongo/jstests/core/arrayfind8.js
+      - mongo/jstests/core/arrayfind9.js
+
+      # https://github.com/FerretDB/FerretDB/issues/1492
+      - mongo/jstests/core/auth1.js
+
+      # https://github.com/FerretDB/FerretDB/issues/1750
+      # logout deprecated since version 5.0.
+      - mongo/jstests/core/auth2.js
+
+      # https://github.com/FerretDB/FerretDB/issues/1745
+      - mongo/jstests/core/find_and_modify.js
+      - mongo/jstests/core/find_and_modify2.js
+      - mongo/jstests/core/find_and_modify3.js
+      - mongo/jstests/core/find_and_modify4.js
+
+      # https://github.com/FerretDB/FerretDB/issues/1384
+      - mongo/jstests/core/uniqueness.js
+
+      # https://github.com/FerretDB/FerretDB/issues/1242
+      - mongo/jstests/core/unset2.js
+
+      # https://github.com/FerretDB/FerretDB/issues/503
+      - mongo/jstests/core/update8.js
+      - mongo/jstests/core/updatec.js
+      - mongo/jstests/core/updatea.js
+      - mongo/jstests/core/updatei.js
+      - mongo/jstests/core/updatej.js
+
+      # https://github.com/FerretDB/FerretDB/issues/503
+      # https://github.com/FerretDB/FerretDB/issues/1736
+      - mongo/jstests/core/update9.js
+
+      # https://github.com/FerretDB/FerretDB/issues/1742
+      - mongo/jstests/core/updateb.js
+      - mongo/jstests/core/updatel.js
+
+      # https://github.com/FerretDB/FerretDB/issues/1744
+      - mongo/jstests/core/updatee.js
+
+      # https://github.com/FerretDB/dance/issues/304
+      - mongo/jstests/core/updatef.js
+
+      # https://docs.ferretdb.io/diff/
+      # 5. Document restrictions:
+      # document keys must not contain $ or . signs;
+      - mongo/jstests/core/updateh.js
   mongodb:
     stats:
       expected_fail: 1
-      expected_pass: 8
+      expected_pass: 53
     fail:
-      - mongo/jstests/auth/auth1.js
+      # https://github.com/FerretDB/dance/issues/304
+      - mongo/jstests/core/updatef.js


### PR DESCRIPTION
Closes FerretDB/FerretDB#625. 

This tests differences introduced in FerretDB/FerretDB#1760.

* `+INF` upon $mul operator returns error
* `-0` negative zero is converted to `0` positive zero everywhere including insert and update operation.