### PR TITLE
Add `env-repl` to Taskfile

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,6 +1,9 @@
 ---
 version: "3"
 
+vars:
+  REPLSET: postgres mongodb_replset init_mongodb_replset
+
 tasks:
   init-tools:
     dir: tools
@@ -40,9 +43,17 @@ tasks:
     cmds:
       - docker compose build --pull
 
+  env-repl:
+    desc: "A minimal environment for testing a single-node replica set"
+    cmds:
+      - >
+        docker compose up --remove-orphans --renew-anon-volumes --timeout=0 --detach --build {{.REPLSET}}
+      - task: env-logs
+
   env-logs:
     cmds:
-      - docker compose logs --no-color
+      - docker compose ps --all
+      - docker compose logs --follow
 
   env-down:
     desc: "Stop environment"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,35 @@ services:
     volumes:
       - ./tests/mongo:/tests/mongo
 
+  # used for testing a replica set
+  mongodb_replset:
+    build:
+      context: ./build/deps
+      dockerfile: ${MONGO_DOCKERFILE:-mongo6}.Dockerfile
+    container_name: mongodb_replset
+    command: mongod --port 47017 --bind_ip_all --replSet rs0
+    ports:
+      - 47017:27017
+    extra_hosts:
+    - "host.docker.internal:host-gateway"
+    environment:
+      # Always UTC+05:45. Set to catch timezone problems.
+      - TZ=Asia/Kathmandu
+    volumes:
+      - ./build/mongod_repl.conf:/etc/mongod.conf
+  
+  # initiates the replica set
+  # we need a separate container to run rs.initiate()
+  init_mongodb_replset:
+    build:
+      context: ./build/deps
+      dockerfile: ${MONGO_DOCKERFILE:-mongo6}.Dockerfile
+    container_name: init_mongodb_replset
+    depends_on:
+      - mongodb_replset
+    restart: "no"
+    entrypoint: ["bash", "-c", "sleep 10 && mongosh --host mongodb_replset:47017 --eval 'rs.initiate();'"]
+
   # for documentation
   textlint:
     build:


### PR DESCRIPTION
Moved to dance.

This PR adds a task to create a single-node replica set. This is useful for testing the oplog and change streams. I opted to create separate containers but we could just convert all instances to a replica set if that's better. However, that would add more log output by introducing [REPL](https://www.mongodb.com/docs/manual/reference/log-messages/#mongodb-data-REPL) messages.