### PR TITLE
Limit the number of parallel files for `jstest` runner

### DIFF
--- a/internal/jstest/jstest.go
+++ b/internal/jstest/jstest.go
@@ -63,7 +63,7 @@ func Run(ctx context.Context, dir string, args []string) (*internal.TestResults,
 
 	// tokens is a counting semaphore used to enforce a limit of
 	// 20 concurrent runCommand invocations.
-	var tokens = make(chan struct{}, 20)
+	tokens := make(chan struct{}, 20)
 
 	ch := make(chan *item, len(files))
 

--- a/internal/jstest/jstest.go
+++ b/internal/jstest/jstest.go
@@ -61,6 +61,10 @@ func Run(ctx context.Context, dir string, args []string) (*internal.TestResults,
 		out  []byte
 	}
 
+	// tokens is a counting semaphore used to enforce a limit of
+	// 20 concurrent runCommand invocations.
+	var tokens = make(chan struct{}, 20)
+
 	ch := make(chan *item, len(files))
 
 	var wg sync.WaitGroup
@@ -70,6 +74,7 @@ func Run(ctx context.Context, dir string, args []string) (*internal.TestResults,
 		go func(f string) {
 			defer wg.Done()
 
+			tokens <- struct{}{}
 			it := &item{
 				file: f,
 			}
@@ -82,6 +87,8 @@ func Run(ctx context.Context, dir string, args []string) (*internal.TestResults,
 
 			it.out, it.err = runCommand(dir, "mongo", rel)
 			ch <- it
+
+			<-tokens // release the token
 		}(f)
 	}
 


### PR DESCRIPTION
I hard coded a value of 20 for now.