### PR TITLE
Compress CI artifacts

### DIFF
--- a/.github/workflows/dance.yml
+++ b/.github/workflows/dance.yml
@@ -74,15 +74,18 @@ jobs:
       - name: Collect logs
         if: failure()
         run: |
-          bin/task env-logs-collect > /tmp/compose-logs.txt
+          bin/task env-logs-collect > /tmp/compose-logs-${{ matrix.db }}-${{ matrix.test }}.txt
 
-      # TODO zip logs https://github.com/FerretDB/FerretDB/issues/2086
+      - name: Compress logs before upload
+        if: failure()
+        run: zip -q -9 compose-logs.zip /tmp/compose-logs.txt
+
       - name: Upload logs
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: compose-logs-${{ matrix.db }}-${{ matrix.test }}.txt
-          path: /tmp/compose-logs.txt
+          name: compose-logs-${{ matrix.db }}-${{ matrix.test }}
+          path: compose-logs.zip
           retention-days: 1
 
       # ignore `go mod tidy` being applied to the Go driver, etc

--- a/.github/workflows/dance.yml
+++ b/.github/workflows/dance.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Collect logs
         if: failure()
         run: |
-          bin/task env-logs-collect > /tmp/compose-logs-${{ matrix.db }}-${{ matrix.test }}.txt
+          bin/task env-logs-collect > /tmp/compose-logs.txt
 
       - name: Compress logs before upload
         if: failure()

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -75,7 +75,6 @@ tasks:
     desc: "Run all integration tests"
     dir: tests
     cmds:
-      - exit 1 # test CI
       - go run ../cmd/dance -db={{.DB}} {{.TEST}}
     preconditions:
       - sh: "test {{.DB}}"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -75,6 +75,7 @@ tasks:
     desc: "Run all integration tests"
     dir: tests
     cmds:
+      - exit 1 # test CI
       - go run ../cmd/dance -db={{.DB}} {{.TEST}}
     preconditions:
       - sh: "test {{.DB}}"


### PR DESCRIPTION
Closes FerretDB/FerretDB#2086.

##  Before compression
https://github.com/FerretDB/dance/actions/runs/4691597157 6.9 - 11.9 KB

## After compression
https://github.com/FerretDB/dance/actions/runs/4692780544 2.47 - 2.89 KB.