### PR TITLE
Allow uppercase Latin letters in database names

### DIFF
--- a/tests/diff.yml
+++ b/tests/diff.yml
@@ -5,8 +5,8 @@ args: ["-timeout=30s", "-shuffle=on", "-race", "./..."]
 results:
   ferretdb:
     stats:
-      expected_fail: 77
-      expected_pass: 31
+      expected_fail: 75
+      expected_pass: 30
 
     pass:
       - regex: FerretDB$
@@ -16,8 +16,8 @@ results:
 
   mongodb:
     stats:
-      expected_fail: 77
-      expected_pass: 31
+      expected_fail: 75
+      expected_pass: 30
 
     pass:
       - regex: MongoDB$

--- a/tests/diff/names_test.go
+++ b/tests/diff/names_test.go
@@ -32,7 +32,6 @@ func TestDatabaseName(t *testing.T) {
 		"ReservedPrefix":     "_ferretdb_xxx",
 		"NonLatin":           "データベース",
 		"StartingWithNumber": "1database",
-		"CapitalLetter":      "Database",
 	}
 
 	for name, dbName := range testCases {


### PR DESCRIPTION
Closes https://github.com/FerretDB/FerretDB/issues/2451.

As uppercase letters are allowed, we should remove a diff test for it.