### PR TITLE
Stream go-ycsb output

### DIFF
--- a/.github/workflows/dance.yml
+++ b/.github/workflows/dance.yml
@@ -41,8 +41,8 @@ jobs:
           - mongo
           - mongo-go-driver
           - mongo-tools
-          - ycsb1
-          - ycsb2
+          - ycsb-workloada
+          - ycsb-workloadc
 
     steps:
       - name: Checkout code

--- a/cmd/dance/main.go
+++ b/cmd/dance/main.go
@@ -134,7 +134,7 @@ func main() {
 		case internal.RunnerTypeJSTest:
 			runRes, err = jstest.Run(ctx, dir, config.Args)
 		case internal.RunnerTypeYCSB:
-			runRes, err = ycsb.Run(ctx, dir, config.Args, *vF)
+			runRes, err = ycsb.Run(ctx, dir, config.Args)
 		default:
 			log.Fatalf("unknown runner: %q", config.Runner)
 		}

--- a/cmd/dance/main.go
+++ b/cmd/dance/main.go
@@ -134,7 +134,7 @@ func main() {
 		case internal.RunnerTypeJSTest:
 			runRes, err = jstest.Run(ctx, dir, config.Args)
 		case internal.RunnerTypeYCSB:
-			runRes, err = ycsb.Run(ctx, dir, config.Args)
+			runRes, err = ycsb.Run(ctx, dir, config.Args, *vF)
 		default:
 			log.Fatalf("unknown runner: %q", config.Runner)
 		}

--- a/tests/ycsb-workloada.yml
+++ b/tests/ycsb-workloada.yml
@@ -1,9 +1,9 @@
 ---
+# Workload A: Update heavy workload
 runner: ycsb
 dir: ycsb
 args:
-  # the first argument must be a workload file.
-  - workloads/workloadc # Workload C: Read only
+  - workloads/workloada
   - recordcount=5000
 
 results:

--- a/tests/ycsb-workloadc.yml
+++ b/tests/ycsb-workloadc.yml
@@ -1,9 +1,9 @@
 ---
+# Workload C: Read only
 runner: ycsb
 dir: ycsb
 args:
-  # the first argument must be a workload file.
-  - workloads/workloada # Workload A: Update heavy workload
+  - workloads/workloadc
   - recordcount=5000
 
 results:

--- a/tests/ycsb/workloads/workload_template
+++ b/tests/ycsb/workloads/workload_template
@@ -22,8 +22,8 @@
 # out. When a property has a finite number of settings,
 # the default is enabled and the alternates are shown in
 # comments below it.
-# 
-# Use of most explained through comments in Client.java or 
+#
+# Use of most explained through comments in Client.java or
 # CoreWorkload.java or on the YCSB wiki page:
 # https://github.com/brianfrankcooper/YCSB/wiki/Core-Properties
 
@@ -33,7 +33,7 @@ workload=core
 # There is no default setting for recordcount but it is
 # required to be set.
 # The number of records in the table to be inserted in
-# the load phase or the number of records already in the 
+# the load phase or the number of records already in the
 # table before the run phase.
 recordcount=1000000
 
@@ -43,7 +43,7 @@ recordcount=1000000
 operationcount=3000000
 
 # The number of thread.
-threadcount=500 
+threadcount=500
 
 # The number of insertions to do, if different from recordcount.
 # Used with insertstart to grow an existing table.
@@ -107,7 +107,7 @@ hotspotdatafraction=0.2
 hotspotopnfraction=0.8
 
 # Maximum execution time in seconds
-#maxexecutiontime= 
+#maxexecutiontime=
 
 # The name of the database table to run queries against
 table=usertable
@@ -141,7 +141,7 @@ measurementtype=histogram
 # Measure JVM information over time including GC counts, max and min memory
 # used, max and min thread counts, max and min system load and others. This
 # setting must be enabled in conjunction with the "-s" flag to run the status
-# thread. Every "status.interval", the status thread will capture JVM 
+# thread. Every "status.interval", the status thread will capture JVM
 # statistics and record the results. At the end of the run, max and mins will
 # be recorded.
 # measurement.trackjvm = false

--- a/tests/ycsb/workloads/workloada
+++ b/tests/ycsb/workloads/workloada
@@ -1,23 +1,23 @@
-# Copyright (c) 2010 Yahoo! Inc. All rights reserved.                                                                                                                             
-#                                                                                                                                                                                 
-# Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
-# may not use this file except in compliance with the License. You                                                                                                                
-# may obtain a copy of the License at                                                                                                                                             
-#                                                                                                                                                                                 
-# http://www.apache.org/licenses/LICENSE-2.0                                                                                                                                      
-#                                                                                                                                                                                 
-# Unless required by applicable law or agreed to in writing, software                                                                                                             
-# distributed under the License is distributed on an "AS IS" BASIS,                                                                                                               
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                                                                                                                 
-# implied. See the License for the specific language governing                                                                                                                    
-# permissions and limitations under the License. See accompanying                                                                                                                 
-# LICENSE file.                                                                                                                                                                   
+# Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You
+# may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See accompanying
+# LICENSE file.
 
 
 # Yahoo! Cloud System Benchmark
 # Workload A: Update heavy workload
 #   Application example: Session store recording recent actions
-#                        
+#
 #   Read/update ratio: 50/50
 #   Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
 #   Request distribution: zipfian
@@ -34,4 +34,3 @@ scanproportion=0
 insertproportion=0
 
 requestdistribution=uniform
-

--- a/tests/ycsb/workloads/workloadb
+++ b/tests/ycsb/workloads/workloadb
@@ -1,22 +1,22 @@
-# Copyright (c) 2010 Yahoo! Inc. All rights reserved.                                                                                                                             
-#                                                                                                                                                                                 
-# Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
-# may not use this file except in compliance with the License. You                                                                                                                
-# may obtain a copy of the License at                                                                                                                                             
-#                                                                                                                                                                                 
-# http://www.apache.org/licenses/LICENSE-2.0                                                                                                                                      
-#                                                                                                                                                                                 
-# Unless required by applicable law or agreed to in writing, software                                                                                                             
-# distributed under the License is distributed on an "AS IS" BASIS,                                                                                                               
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                                                                                                                 
-# implied. See the License for the specific language governing                                                                                                                    
-# permissions and limitations under the License. See accompanying                                                                                                                 
-# LICENSE file.                                                                                                                                                                   
+# Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You
+# may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See accompanying
+# LICENSE file.
 
 # Yahoo! Cloud System Benchmark
 # Workload B: Read mostly workload
 #   Application example: photo tagging; add a tag is an update, but most operations are to read tags
-#                        
+#
 #   Read/update ratio: 95/5
 #   Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
 #   Request distribution: zipfian
@@ -33,4 +33,3 @@ scanproportion=0
 insertproportion=0
 
 requestdistribution=uniform
-

--- a/tests/ycsb/workloads/workloadc
+++ b/tests/ycsb/workloads/workloadc
@@ -1,22 +1,22 @@
-# Copyright (c) 2010 Yahoo! Inc. All rights reserved.                                                                                                                             
-#                                                                                                                                                                                 
-# Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
-# may not use this file except in compliance with the License. You                                                                                                                
-# may obtain a copy of the License at                                                                                                                                             
-#                                                                                                                                                                                 
-# http://www.apache.org/licenses/LICENSE-2.0                                                                                                                                      
-#                                                                                                                                                                                 
-# Unless required by applicable law or agreed to in writing, software                                                                                                             
-# distributed under the License is distributed on an "AS IS" BASIS,                                                                                                               
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                                                                                                                 
-# implied. See the License for the specific language governing                                                                                                                    
-# permissions and limitations under the License. See accompanying                                                                                                                 
-# LICENSE file.                                                                                                                                                                   
+# Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You
+# may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See accompanying
+# LICENSE file.
 
 # Yahoo! Cloud System Benchmark
 # Workload C: Read only
 #   Application example: user profile cache, where profiles are constructed elsewhere (e.g., Hadoop)
-#                        
+#
 #   Read/update ratio: 100/0
 #   Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
 #   Request distribution: zipfian
@@ -33,6 +33,3 @@ scanproportion=0
 insertproportion=0
 
 requestdistribution=uniform
-
-
-

--- a/tests/ycsb/workloads/workloadd
+++ b/tests/ycsb/workloads/workloadd
@@ -1,29 +1,29 @@
-# Copyright (c) 2010 Yahoo! Inc. All rights reserved.                                                                                                                             
-#                                                                                                                                                                                 
-# Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
-# may not use this file except in compliance with the License. You                                                                                                                
-# may obtain a copy of the License at                                                                                                                                             
-#                                                                                                                                                                                 
-# http://www.apache.org/licenses/LICENSE-2.0                                                                                                                                      
-#                                                                                                                                                                                 
-# Unless required by applicable law or agreed to in writing, software                                                                                                             
-# distributed under the License is distributed on an "AS IS" BASIS,                                                                                                               
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                                                                                                                 
-# implied. See the License for the specific language governing                                                                                                                    
-# permissions and limitations under the License. See accompanying                                                                                                                 
-# LICENSE file.                                                                                                                                                                   
+# Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You
+# may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See accompanying
+# LICENSE file.
 
 # Yahoo! Cloud System Benchmark
 # Workload D: Read latest workload
 #   Application example: user status updates; people want to read the latest
-#                        
+#
 #   Read/update/insert ratio: 95/0/5
 #   Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
 #   Request distribution: latest
 
-# The insert order for this is hashed, not ordered. The "latest" items may be 
+# The insert order for this is hashed, not ordered. The "latest" items may be
 # scattered around the keyspace if they are keyed by userid.timestamp. A workload
-# which orders items purely by time, and demands the latest, is very different than 
+# which orders items purely by time, and demands the latest, is very different than
 # workload here (which we believe is more typical of how people build systems.)
 
 recordcount=1000
@@ -38,4 +38,3 @@ scanproportion=0
 insertproportion=0.05
 
 requestdistribution=latest
-

--- a/tests/ycsb/workloads/workloade
+++ b/tests/ycsb/workloads/workloade
@@ -1,22 +1,22 @@
-# Copyright (c) 2010 Yahoo! Inc. All rights reserved.                                                                                                                             
-#                                                                                                                                                                                 
-# Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
-# may not use this file except in compliance with the License. You                                                                                                                
-# may obtain a copy of the License at                                                                                                                                             
-#                                                                                                                                                                                 
-# http://www.apache.org/licenses/LICENSE-2.0                                                                                                                                      
-#                                                                                                                                                                                 
-# Unless required by applicable law or agreed to in writing, software                                                                                                             
-# distributed under the License is distributed on an "AS IS" BASIS,                                                                                                               
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                                                                                                                 
-# implied. See the License for the specific language governing                                                                                                                    
-# permissions and limitations under the License. See accompanying                                                                                                                 
-# LICENSE file.                                                                                                                                                                   
+# Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You
+# may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See accompanying
+# LICENSE file.
 
 # Yahoo! Cloud System Benchmark
 # Workload E: Short ranges
 #   Application example: threaded conversations, where each scan is for the posts in a given thread (assumed to be clustered by thread id)
-#                        
+#
 #   Scan/insert ratio: 95/5
 #   Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
 #   Request distribution: zipfian
@@ -42,5 +42,3 @@ requestdistribution=uniform
 maxscanlength=1
 
 scanlengthdistribution=uniform
-
-

--- a/tests/ycsb/workloads/workloadf
+++ b/tests/ycsb/workloads/workloadf
@@ -1,22 +1,22 @@
-# Copyright (c) 2010 Yahoo! Inc. All rights reserved.                                                                                                                             
-#                                                                                                                                                                                 
-# Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
-# may not use this file except in compliance with the License. You                                                                                                                
-# may obtain a copy of the License at                                                                                                                                             
-#                                                                                                                                                                                 
-# http://www.apache.org/licenses/LICENSE-2.0                                                                                                                                      
-#                                                                                                                                                                                 
-# Unless required by applicable law or agreed to in writing, software                                                                                                             
-# distributed under the License is distributed on an "AS IS" BASIS,                                                                                                               
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                                                                                                                 
-# implied. See the License for the specific language governing                                                                                                                    
-# permissions and limitations under the License. See accompanying                                                                                                                 
-# LICENSE file.                                                                                                                                                                   
+# Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You
+# may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See accompanying
+# LICENSE file.
 
 # Yahoo! Cloud System Benchmark
 # Workload F: Read-modify-write workload
 #   Application example: user database, where user records are read and modified by the user or to record user activity.
-#                        
+#
 #   Read/read-modify-write ratio: 50/50
 #   Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
 #   Request distribution: zipfian
@@ -34,4 +34,3 @@ insertproportion=0
 readmodifywriteproportion=0.5
 
 requestdistribution=uniform
-


### PR DESCRIPTION
This runner is one-per-test, so there is no need to collect output.