### PR TITLE
Fix diff test

### DIFF
--- a/tests/diff/dbstats_scale_test.go
+++ b/tests/diff/dbstats_scale_test.go
@@ -58,7 +58,7 @@ func TestDBStatsScale(t *testing.T) {
 			expectedFerretDBErr: mongo.CommandError{
 				Name:    "Location51024",
 				Code:    51024,
-				Message: "BSON field 'scale' value must be >= 1, actual value '-2147483648'",
+				Message: "BSON field 'scale' value must be >= 1, actual value '-9223372036854775808'",
 			},
 		},
 		"String": {


### PR DESCRIPTION
`scale` parameter can now store an int64 because of [this](https://github.com/FerretDB/FerretDB/commit/263c3fe70be732b0283dbfa97da7f920a14f8e08#diff-96ce309aaf377642b38ebb97647a854ffe20758797f6fab92081955f54c9ef5bR42).