### PR TITLE
Log the pass rate on CI

### DIFF
--- a/cmd/dance/main.go
+++ b/cmd/dance/main.go
@@ -20,12 +20,14 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/pmezard/go-difflib/difflib"
+	"github.com/sethvargo/go-githubactions"
 	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v3"
 
@@ -200,6 +202,22 @@ func main() {
 		}
 		if diff != "" {
 			log.Fatalf("\nUnexpected stats:\n%s", diff)
+		}
+
+		totalRun := compareRes.Stats.ExpectedFail + compareRes.Stats.ExpectedSkip + compareRes.Stats.ExpectedPass
+		msg := fmt.Sprintf(
+			"%.2f%% (%d/%d) tests passed.",
+			float64(compareRes.Stats.ExpectedPass)/float64(totalRun)*100,
+			compareRes.Stats.ExpectedPass,
+			totalRun,
+		)
+		log.Print(msg)
+
+		// Make percentage more visible on GitHub Actions.
+		// https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+		if os.Getenv("GITHUB_ACTIONS") == "true" {
+			action := githubactions.New()
+			action.Noticef("%s", msg)
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21.1
 require (
 	github.com/AlekSi/pointer v1.2.0
 	github.com/pmezard/go-difflib v1.0.0
+	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/stretchr/testify v1.8.4
 	go.mongodb.org/mongo-driver v1.12.1
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
@@ -17,6 +18,7 @@ require (
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
+	github.com/sethvargo/go-envconfig v0.8.0 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,10 @@ github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe h1:iruDEfMl2E6f
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sethvargo/go-envconfig v0.8.0 h1:AcmdAewSFAc7pQ1Ghz+vhZkilUtxX559QlDuLLiSkdI=
+github.com/sethvargo/go-envconfig v0.8.0/go.mod h1:Iz1Gy1Sf3T64TQlJSvee81qDhf7YIlt8GMUX6yyNFs0=
+github.com/sethvargo/go-githubactions v1.1.0 h1:mg03w+b+/s5SMS298/2G6tHv8P0w0VhUFaqL1THIqzY=
+github.com/sethvargo/go-githubactions v1.1.0/go.mod h1:qIboSF7yq2Qnaw2WXDsqCReM0Lo1gU4QXUWmhBC3pxE=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=


### PR DESCRIPTION
Closes #327.

Created a new PR to avoid having to deal with merge conflicts on abandoned [PR](https://github.com/FerretDB/dance/pull/327).

We should calculate the pass rate cumulatively for each segment of `dbaas_core` _then_ log to CI. This can be done in a follow up PR.