### PR TITLE
Fix authentication error

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -148,8 +148,6 @@ tasks:
         sed 's/FERRETDB_TEST_ENABLE_NEW_AUTH=false/FERRETDB_TEST_ENABLE_NEW_AUTH=true/g' docker-compose.yml |
         sed 's/- POSTGRES_HOST_AUTH_METHOD=trust//g' |
         sed -e '/POSTGRES_DB=dance/N' -e 's/\n//' > temp.yml
-    # ignore already enabled error
-    ignore_error: true
 
   # see https://github.com/DavidAnson/markdownlint-cli2#command-line for the reason we use double-quotes
   docs-fmt:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -147,7 +147,7 @@ tasks:
       - >
         sed 's/FERRETDB_TEST_ENABLE_NEW_AUTH=false/FERRETDB_TEST_ENABLE_NEW_AUTH=true/g' docker-compose.yml |
         sed 's/- POSTGRES_HOST_AUTH_METHOD=trust//g' |
-        sed -e '/POSTGRES_DB=dance/N' -e 's/\n//' > temp.yml
+        sed -e '/POSTGRES_DB=dance/N' -e 's/\n//' > temp.yml && mv temp.yml docker-compose.yml
 
   # see https://github.com/DavidAnson/markdownlint-cli2#command-line for the reason we use double-quotes
   docs-fmt:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -38,10 +38,10 @@ tasks:
       # use -t instead of --timeout / --wait-timeout to be compatible with all versions:
       # https://github.com/docker/compose/issues/10269#issuecomment-1495205234
       - >
-        docker compose up --always-recreate-deps --force-recreate --remove-orphans --renew-anon-volumes -t 0 --detach
+        docker compose up --always-recreate-deps --force-recreate --remove-orphans -t 0 --detach
         --build {{.DB}}
       - task: init-repl
-      - task: init-user
+      - task: insert-user
     preconditions:
       - sh: "test {{.DB}}"
         msg: "Please set DB variable to one of `postgresql`, `sqlite`, or `mongodb`"
@@ -126,8 +126,29 @@ tasks:
       - >
         docker compose run --rm mongosh mongosh
         'mongodb://host.docker.internal:27017/'
-        --verbose --eval 'db.getSiblingDB("admin").createUser({user: "user", pwd: "password", roles: [ "root" ]})'
+        --verbose --eval 'db.getSiblingDB("admin").createUser({user: "username", pwd: "password", roles: [ "root" ]})'
     # ignore roles that are not implemented yet
+    ignore_error: true
+
+  insert-user:
+    desc: "Inserts a user document directly into the system.users collection"
+    cmds:
+      - >
+        docker compose run --rm mongosh mongosh
+        'mongodb://host.docker.internal:27017/'
+        --verbose --eval
+        'db.getSiblingDB("admin").system.users.insert({"_id" : "test.username", "userId" : UUID("b7636cbc-99ac-4c87-8d2f-7a50380bc8f0"), "user" : "username", "db" : "test", "credentials" : {"SCRAM-SHA-1" : {"iterationCount" : NumberInt(10000),"salt" : "PBoLVqXQCk0E/9XXXTFw6A==","storedKey" : "wvNh1m3FSUwgCBn/rEINz1NGVdY=","serverKey" : "4Fnmuta3kZmBNxG94IjZq6/Tucg="},"SCRAM-SHA-256" : {"iterationCount" : NumberInt(15000),"salt" : "GdzhsVThC0oP+PYngC2B0wwXFRuR/xP6rpnxJA==","storedKey" : "1IEtAJyQjKCaVCpRrTlifHSHIW5d0SOn7UaiCTGYCTc=","serverKey" : "IdXlVuMnJ8df3PGg9rgx6q/UiODlEqJqu4IiNT75YvA="}},"roles" : [ ]});'
+    # ignore duplicate key error
+    ignore_error: true
+
+  disable-trust-enable-scram:
+    desc: "Disables trust authentication and enables SCRAM"
+    cmds:
+      - >
+        sed 's/FERRETDB_TEST_ENABLE_NEW_AUTH=false/FERRETDB_TEST_ENABLE_NEW_AUTH=true/g' docker-compose.yml |
+        sed 's/- POSTGRES_HOST_AUTH_METHOD=trust//g' |
+        sed -e '/POSTGRES_DB=dance/N' -e 's/\n//' > temp.yml
+    # ignore already enabled error
     ignore_error: true
 
   # see https://github.com/DavidAnson/markdownlint-cli2#command-line for the reason we use double-quotes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - FERRETDB_HANDLER=postgresql
       - FERRETDB_POSTGRESQL_URL=postgres://username@postgres:5432/dance
       - FERRETDB_REPL_SET_NAME=rs0
-      - FERRETDB_TEST_ENABLE_NEW_AUTH=true
+      - FERRETDB_TEST_ENABLE_NEW_AUTH=false
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
@@ -29,7 +29,7 @@ services:
       - FERRETDB_HANDLER=sqlite
       - FERRETDB_SQLITE_URL=file:/state/?_pragma=busy_timeout(20000)
       - FERRETDB_REPL_SET_NAME=rs0
-      - FERRETDB_TEST_ENABLE_NEW_AUTH=true
+      - FERRETDB_TEST_ENABLE_NEW_AUTH=false
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
@@ -45,7 +45,8 @@ services:
       # UTC−03:30/−02:30. Set to catch timezone problems.
       - TZ=America/St_Johns
       - POSTGRES_USER=username
-      - POSTGRES_DB=dance      
+      - POSTGRES_DB=dance
+      - POSTGRES_HOST_AUTH_METHOD=trust
 
   mongodb:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - FERRETDB_HANDLER=postgresql
       - FERRETDB_POSTGRESQL_URL=postgres://username@postgres:5432/dance
       - FERRETDB_REPL_SET_NAME=rs0
-      - FERRETDB_TEST_ENABLE_NEW_AUTH=false
+      - FERRETDB_TEST_ENABLE_NEW_AUTH=true
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
@@ -29,7 +29,7 @@ services:
       - FERRETDB_HANDLER=sqlite
       - FERRETDB_SQLITE_URL=file:/state/?_pragma=busy_timeout(20000)
       - FERRETDB_REPL_SET_NAME=rs0
-      - FERRETDB_TEST_ENABLE_NEW_AUTH=false
+      - FERRETDB_TEST_ENABLE_NEW_AUTH=true
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
@@ -45,8 +45,7 @@ services:
       # UTC−03:30/−02:30. Set to catch timezone problems.
       - TZ=America/St_Johns
       - POSTGRES_USER=username
-      - POSTGRES_DB=dance
-      - POSTGRES_HOST_AUTH_METHOD=trust
+      - POSTGRES_DB=dance      
 
   mongodb:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,9 @@ services:
       # Always UTC+05:45. Set to catch timezone problems.
       - TZ=Asia/Kathmandu
       - FERRETDB_HANDLER=postgresql
-      - FERRETDB_POSTGRESQL_URL=postgres://user@postgres:5432/dance
+      - FERRETDB_POSTGRESQL_URL=postgres://username@postgres:5432/dance
       - FERRETDB_REPL_SET_NAME=rs0
-      - FERRETDB_TEST_ENABLE_NEW_AUTH=true
+      - FERRETDB_TEST_ENABLE_NEW_AUTH=false
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
@@ -29,7 +29,7 @@ services:
       - FERRETDB_HANDLER=sqlite
       - FERRETDB_SQLITE_URL=file:/state/?_pragma=busy_timeout(20000)
       - FERRETDB_REPL_SET_NAME=rs0
-      - FERRETDB_TEST_ENABLE_NEW_AUTH=true
+      - FERRETDB_TEST_ENABLE_NEW_AUTH=false
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
@@ -44,7 +44,7 @@ services:
     environment:
       # UTC−03:30/−02:30. Set to catch timezone problems.
       - TZ=America/St_Johns
-      - POSTGRES_USER=user
+      - POSTGRES_USER=username
       - POSTGRES_DB=dance
       - POSTGRES_HOST_AUTH_METHOD=trust
 


### PR DESCRIPTION
Just an idea to fix the dance issue.

1. create a new command to insert a user document directly into the `admin.system.users` collection in the Taskfile
2. remove `--renew-anon-volumes` from `env-up-detach` so that the document persists after we restart the container
3. set `FERRETDB_TEST_ENABLE_NEW_AUTH` to false, and `POSTGRES_HOST_AUTH_METHOD=trust` in the compose file - if trust not set 'hostname resolving error (lookup postgres on 127.0.0.11:53: server misbehaving)'
4. set `FERRETDB_TEST_ENABLE_NEW_AUTH` to true and remove trust
5. restart container via `env-up` command