### PR TITLE
Parse metrics produced by `go-ycsb`

### DIFF
--- a/internal/ycsb/ycsb.go
+++ b/internal/ycsb/ycsb.go
@@ -180,5 +180,9 @@ func parseMeasurements(output string) map[string]Measurements {
 		}
 	}
 
+	if err := scanner.Err(); err != nil {
+		panic(scanner.Err())
+	}
+
 	return res
 }

--- a/internal/ycsb/ycsb.go
+++ b/internal/ycsb/ycsb.go
@@ -103,7 +103,12 @@ func Run(ctx context.Context, dir string, args []string) (*config.TestResults, e
 		},
 	}
 
-	err = cmd.Run()
+	err = cmd.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	err = cmd.Wait()
 
 	switch err {
 	case nil:

--- a/internal/ycsb/ycsb.go
+++ b/internal/ycsb/ycsb.go
@@ -16,15 +16,34 @@
 package ycsb
 
 import (
+	"bufio"
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/FerretDB/dance/internal/config"
 )
+
+// Measurements stores go-ycsb results.
+type Measurements struct {
+	Takes    time.Duration
+	Count    int64
+	OPS      float64
+	Avg      time.Duration
+	Min      time.Duration
+	Max      time.Duration
+	Perc50   time.Duration
+	Perc90   time.Duration
+	Perc95   time.Duration
+	Perc99   time.Duration
+	Perc999  time.Duration
+	Perc9999 time.Duration
+}
 
 // Run runs `go-ycsb`.
 //
@@ -63,8 +82,6 @@ func Run(ctx context.Context, dir string, args []string) (*config.TestResults, e
 
 	cmd = exec.CommandContext(ctx, bin, cliArgs...)
 	cmd.Dir = dir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
 
 	log.Printf("Running %s", strings.Join(cmd.Args, " "))
 
@@ -76,7 +93,14 @@ func Run(ctx context.Context, dir string, args []string) (*config.TestResults, e
 		},
 	}
 
-	if err := cmd.Run(); err != nil {
+	output, err := cmd.CombinedOutput()
+	soutput := string(output)
+	fmt.Println(soutput)
+
+	switch err {
+	case nil:
+		fmt.Printf("Parsed metrics: %+v\n\n", parseMeasurements(soutput))
+	default:
 		res.TestResults[dir] = config.TestResult{
 			Status: config.Fail,
 			Output: err.Error(),
@@ -84,4 +108,59 @@ func Run(ctx context.Context, dir string, args []string) (*config.TestResults, e
 	}
 
 	return res, nil
+}
+
+// parseMeasurements parses go-ycsb results.
+func parseMeasurements(output string) map[string]Measurements {
+	res := make(map[string]Measurements)
+
+	scanner := bufio.NewScanner(strings.NewReader(output))
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+
+		if len(fields) == 0 {
+			continue
+		}
+
+		prefix := fields[0]
+
+		switch prefix {
+		case "TOTAL", "READ", "INSERT", "UPDATE":
+			var parsedPrefix string
+			var takes, ops float64
+			var count, avg, vmin, vmax, perc50, perc90, perc95, perc99, perc999, perc9999 int64
+
+			// It is enough to use fmt.Sscanf for parsing the data as the string produced by go-ycsb has fixed format:
+			// https://github.com/pingcap/go-ycsb/blob/fe11c4783b57703465ec7d36fcc4268979001d1a/pkg/measurement/measurement.go#L28
+			_, err := fmt.Sscanf(line,
+				"%s - Takes(s): %f, Count: %d, OPS: %f, Avg(us): %d, Min(us): %d, Max(us): %d, "+
+					"50th(us): %d, 90th(us): %d, 95th(us): %d, 99th(us): %d, 99.9th(us): %d, 99.99th(us): %d",
+				&parsedPrefix, &takes, &count, &ops, &avg, &vmin, &vmax, &perc50, &perc90, &perc95, &perc99, &perc999, &perc9999,
+			)
+			if err != nil {
+				panic(err)
+			}
+
+			res[prefix] = Measurements{
+				Takes:    time.Duration(takes * float64(time.Second)),
+				Count:    count,
+				OPS:      ops,
+				Avg:      time.Duration(avg * int64(time.Microsecond)),
+				Min:      time.Duration(vmin * int64(time.Microsecond)),
+				Max:      time.Duration(vmax * int64(time.Microsecond)),
+				Perc50:   time.Duration(perc50 * int64(time.Microsecond)),
+				Perc90:   time.Duration(perc90 * int64(time.Microsecond)),
+				Perc95:   time.Duration(perc95 * int64(time.Microsecond)),
+				Perc99:   time.Duration(perc99 * int64(time.Microsecond)),
+				Perc999:  time.Duration(perc999 * int64(time.Microsecond)),
+				Perc9999: time.Duration(perc9999 * int64(time.Microsecond)),
+			}
+		default:
+			// string doesn't contain metrics, do nothing
+		}
+	}
+
+	return res
 }

--- a/internal/ycsb/ycsb.go
+++ b/internal/ycsb/ycsb.go
@@ -73,6 +73,7 @@ func Run(ctx context.Context, dir string, args []string) (*config.TestResults, e
 
 	log.Printf("Running %s", strings.Join(cmd.Args, " "))
 
+	// FIXME ?
 	if err := cmd.Run(); err != nil {
 		return nil, err
 	}

--- a/internal/ycsb/ycsb_test.go
+++ b/internal/ycsb/ycsb_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseMeasurements(t *testing.T) {
@@ -53,7 +54,9 @@ TOTAL  - Takes(s): 26.0, Count: 100000, OPS: 3852.6, Avg(us): 257, Min(us): 138,
 UPDATE - Takes(s): 26.0, Count: 49784, OPS: 1918.0, Avg(us): 267, Min(us): 153, Max(us): 52799, 50th(us): 260, 90th(us): 304, 95th(us): 328, 99th(us): 430, 99.9th(us): 1684, 99.99th(us): 2979
 `) + "\n")
 
-	actual := parseMeasurements(output)
+	actual, err := parseMeasurements(output)
+	require.NoError(t, err)
+
 	expected := map[string]Measurements{
 		"READ": {
 			Takes:    26 * time.Second,

--- a/internal/ycsb/ycsb_test.go
+++ b/internal/ycsb/ycsb_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestParseMeasurements(t *testing.T) {
 	//nolint:lll // verbatim output
-	output := strings.TrimSpace(`
+	output := strings.NewReader(strings.TrimSpace(`
 Using request distribution 'uniform' a keyrange of [0 4999]
 Connected to MongoDB!
 ***************** properties *****************
@@ -51,7 +51,7 @@ Run finished, takes 25.957181042s
 READ   - Takes(s): 26.0, Count: 50216, OPS: 1934.6, Avg(us): 246, Min(us): 138, Max(us): 9735, 50th(us): 243, 90th(us): 284, 95th(us): 305, 99th(us): 381, 99.9th(us): 692, 99.99th(us): 2871
 TOTAL  - Takes(s): 26.0, Count: 100000, OPS: 3852.6, Avg(us): 257, Min(us): 138, Max(us): 52799, 50th(us): 251, 90th(us): 296, 95th(us): 318, 99th(us): 405, 99.9th(us): 848, 99.99th(us): 2979
 UPDATE - Takes(s): 26.0, Count: 49784, OPS: 1918.0, Avg(us): 267, Min(us): 153, Max(us): 52799, 50th(us): 260, 90th(us): 304, 95th(us): 328, 99th(us): 430, 99.9th(us): 1684, 99.99th(us): 2979
-`) + "\n"
+`) + "\n")
 
 	actual := parseMeasurements(output)
 	expected := map[string]Measurements{

--- a/internal/ycsb/ycsb_test.go
+++ b/internal/ycsb/ycsb_test.go
@@ -1,0 +1,102 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ycsb
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseMeasurements(t *testing.T) {
+	//nolint:lll // verbatim output
+	output := strings.TrimSpace(`
+Using request distribution 'uniform' a keyrange of [0 4999]
+Connected to MongoDB!
+***************** properties *****************
+"insertproportion"="0"
+"requestdistribution"="uniform"
+"readproportion"="0.5"
+"updateproportion"="0.5"
+"command"="run"
+"workload"="core"
+"dotransactions"="true"
+"scanproportion"="0"
+"readallfields"="true"
+"recordcount"="5000"
+"operationcount"="100000"
+**********************************************
+READ   - Takes(s): 10.0, Count: 19332, OPS: 1933.3, Avg(us): 247, Min(us): 138, Max(us): 1110, 50th(us): 243, 90th(us): 289, 95th(us): 317, 99th(us): 407, 99.9th(us): 661, 99.99th(us): 871
+TOTAL  - Takes(s): 10.0, Count: 38456, OPS: 3845.7, Avg(us): 257, Min(us): 138, Max(us): 2773, 50th(us): 252, 90th(us): 302, 95th(us): 331, 99th(us): 441, 99.9th(us): 751, 99.99th(us): 1784
+UPDATE - Takes(s): 10.0, Count: 19124, OPS: 1912.6, Avg(us): 268, Min(us): 155, Max(us): 2773, 50th(us): 261, 90th(us): 310, 95th(us): 344, 99th(us): 475, 99.9th(us): 1218, 99.99th(us): 1803
+READ   - Takes(s): 20.0, Count: 38557, OPS: 1927.9, Avg(us): 247, Min(us): 138, Max(us): 5299, 50th(us): 243, 90th(us): 285, 95th(us): 307, 99th(us): 390, 99.9th(us): 711, 99.99th(us): 2871
+TOTAL  - Takes(s): 20.0, Count: 76910, OPS: 3845.6, Avg(us): 257, Min(us): 138, Max(us): 52799, 50th(us): 251, 90th(us): 297, 95th(us): 320, 99th(us): 417, 99.9th(us): 969, 99.99th(us): 2979
+UPDATE - Takes(s): 20.0, Count: 38353, OPS: 1917.8, Avg(us): 268, Min(us): 155, Max(us): 52799, 50th(us): 260, 90th(us): 305, 95th(us): 329, 99th(us): 441, 99.9th(us): 1720, 99.99th(us): 2979
+**********************************************
+Run finished, takes 25.957181042s
+READ   - Takes(s): 26.0, Count: 50216, OPS: 1934.6, Avg(us): 246, Min(us): 138, Max(us): 9735, 50th(us): 243, 90th(us): 284, 95th(us): 305, 99th(us): 381, 99.9th(us): 692, 99.99th(us): 2871
+TOTAL  - Takes(s): 26.0, Count: 100000, OPS: 3852.6, Avg(us): 257, Min(us): 138, Max(us): 52799, 50th(us): 251, 90th(us): 296, 95th(us): 318, 99th(us): 405, 99.9th(us): 848, 99.99th(us): 2979
+UPDATE - Takes(s): 26.0, Count: 49784, OPS: 1918.0, Avg(us): 267, Min(us): 153, Max(us): 52799, 50th(us): 260, 90th(us): 304, 95th(us): 328, 99th(us): 430, 99.9th(us): 1684, 99.99th(us): 2979
+`) + "\n"
+
+	actual := parseMeasurements(output)
+	expected := map[string]Measurements{
+		"READ": {
+			Takes:    26 * time.Second,
+			Count:    50216,
+			OPS:      1934.6,
+			Avg:      246 * time.Microsecond,
+			Min:      138 * time.Microsecond,
+			Max:      9735 * time.Microsecond,
+			Perc50:   243 * time.Microsecond,
+			Perc90:   284 * time.Microsecond,
+			Perc95:   305 * time.Microsecond,
+			Perc99:   381 * time.Microsecond,
+			Perc999:  692 * time.Microsecond,
+			Perc9999: 2871 * time.Microsecond,
+		},
+		"TOTAL": {
+			Takes:    26 * time.Second,
+			Count:    100000,
+			OPS:      3852.6,
+			Avg:      257 * time.Microsecond,
+			Min:      138 * time.Microsecond,
+			Max:      52799 * time.Microsecond,
+			Perc50:   251 * time.Microsecond,
+			Perc90:   296 * time.Microsecond,
+			Perc95:   318 * time.Microsecond,
+			Perc99:   405 * time.Microsecond,
+			Perc999:  848 * time.Microsecond,
+			Perc9999: 2979 * time.Microsecond,
+		},
+		"UPDATE": {
+			Takes:    26 * time.Second,
+			Count:    49784,
+			OPS:      1918.0,
+			Avg:      267 * time.Microsecond,
+			Min:      153 * time.Microsecond,
+			Max:      52799 * time.Microsecond,
+			Perc50:   260 * time.Microsecond,
+			Perc90:   304 * time.Microsecond,
+			Perc95:   328 * time.Microsecond,
+			Perc99:   430 * time.Microsecond,
+			Perc999:  1684 * time.Microsecond,
+			Perc9999: 2979 * time.Microsecond,
+		},
+	}
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
**Note:** in the `go-ycsb` code I see json as output format being mentioned. It would be easier to parse from JSON, but I don't see a way to set it. 

Closes #943.