### PR TITLE
Update `mongo-tools` project for FerretDB v1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - ./build/mongod_secured.conf:/etc/mongod.conf
 
   ferretdb-postgresql:
-    image: ghcr.io/ferretdb/ferretdb:1
+    image: ghcr.io/ferretdb/ferretdb-dev:pr-ignore-param
     restart: on-failure
     depends_on: ["postgres"]
     ports:


### PR DESCRIPTION
Closes FerretDB/FerretDB#5147.