### PR TITLE
Allow flexibility to the format of measurements

### DIFF
--- a/internal/pusher/pusher.go
+++ b/internal/pusher/pusher.go
@@ -131,7 +131,7 @@ func (c *Client) Push(ctx context.Context, config, database string, res map[stri
 
 	for t, tr := range res {
 		t = strings.ReplaceAll(t, ".", "_") // to make it compatible with FerretDB v1
-		passed = append(passed, bson.E{t, bson.D{{"m", tr.Measurements}}})
+		passed = append(passed, bson.E{t, bson.D{{"m", tr.Measurements.Values()}}})
 	}
 
 	doc := bson.D{

--- a/internal/runner/ycsb/ycsb.go
+++ b/internal/runner/ycsb/ycsb.go
@@ -49,6 +49,24 @@ type measurement struct {
 	Perc9999Us float64 `json:"99.99th(us),string"`
 }
 
+// Values implements [config.Measurements] interface.
+func (m *measurement) Values() any {
+	return map[string]float64{
+		"takes":    m.TakesS,
+		"count":    float64(m.Count),
+		"ops":      m.OPS,
+		"avg":      (time.Duration(m.AvgUs) * time.Microsecond).Seconds(),
+		"min":      (time.Duration(m.MinUs) * time.Microsecond).Seconds(),
+		"max":      (time.Duration(m.MaxUs) * time.Microsecond).Seconds(),
+		"perc50":   (time.Duration(m.Perc50Us) * time.Microsecond).Seconds(),
+		"perc90":   (time.Duration(m.Perc90Us) * time.Microsecond).Seconds(),
+		"perc95":   (time.Duration(m.Perc95Us) * time.Microsecond).Seconds(),
+		"perc99":   (time.Duration(m.Perc99Us) * time.Microsecond).Seconds(),
+		"perc999":  (time.Duration(m.Perc999Us) * time.Microsecond).Seconds(),
+		"perc9999": (time.Duration(m.Perc9999Us) * time.Microsecond).Seconds(),
+	}
+}
+
 // ycsb represents `ycsb` runner.
 type ycsb struct {
 	p *config.RunnerParamsYCSB
@@ -64,8 +82,8 @@ func New(params *config.RunnerParamsYCSB, l *slog.Logger) (runner.Runner, error)
 }
 
 // parseOutput parses go-ycsb JSON output.
-func parseOutput(r io.Reader) (map[string]map[string]float64, error) {
-	var res map[string]map[string]float64
+func parseOutput(r io.Reader) (map[string]*measurement, error) {
+	var res map[string]*measurement
 
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
@@ -84,22 +102,9 @@ func parseOutput(r io.Reader) (map[string]map[string]float64, error) {
 			return nil, err
 		}
 
-		res = make(map[string]map[string]float64)
+		res = make(map[string]*measurement)
 		for _, m := range ms {
-			res[strings.ToLower(m.Operation)] = map[string]float64{
-				"takes":    m.TakesS,
-				"count":    float64(m.Count),
-				"ops":      m.OPS,
-				"avg":      (time.Duration(m.AvgUs) * time.Microsecond).Seconds(),
-				"min":      (time.Duration(m.MinUs) * time.Microsecond).Seconds(),
-				"max":      (time.Duration(m.MaxUs) * time.Microsecond).Seconds(),
-				"perc50":   (time.Duration(m.Perc50Us) * time.Microsecond).Seconds(),
-				"perc90":   (time.Duration(m.Perc90Us) * time.Microsecond).Seconds(),
-				"perc95":   (time.Duration(m.Perc95Us) * time.Microsecond).Seconds(),
-				"perc99":   (time.Duration(m.Perc99Us) * time.Microsecond).Seconds(),
-				"perc999":  (time.Duration(m.Perc999Us) * time.Microsecond).Seconds(),
-				"perc9999": (time.Duration(m.Perc9999Us) * time.Microsecond).Seconds(),
-			}
+			res[strings.ToLower(m.Operation)] = &m
 		}
 	}
 
@@ -178,3 +183,6 @@ func (y *ycsb) Run(ctx context.Context) (map[string]config.TestResult, error) {
 
 	return run(ctx, args, y.p.Dir)
 }
+
+// check interface
+var _ config.Measurements = (*measurement)(nil)


### PR DESCRIPTION
Closes #1202.

The `mongodb-benchmarking` produces benchmark results that takes measurements every second while the benchmark is running. It looks like below. It doesn't fit well into the current measurement format of `map[string]float64`. This PR makes measurement format a bit more flexible.

```
t,count,mean,m1_rate,m5_rate,m15_rate,mean_rate
1748240899,13524,13522.216068,756.800000,756.800000,756.800000
1748240900,21505,10748.078321,756.800000,756.800000,756.800000
1748240901,27081,9027.363746,756.800000,756.800000,756.800000
1748240902,30000,8288.694528,756.800000,756.800000,756.800000
```